### PR TITLE
yuga: Correct remotes and restructue

### DIFF
--- a/yuga/manifest.xml
+++ b/yuga/manifest.xml
@@ -1,17 +1,15 @@
 <manifest>
-    <remote name="github" fetch="http://github.com" revision="refs/heads/cm-14.1" />
+	<project path="device/sony/yuga" name="Halium/android_device_sony_yuga" revision="halium-7.1" remote="hal" />
+	<project path="kernel/sony/apq8064" name="Halium/android_kernel_sony_apq8064" revision="halium-7.1" remote="hal" />
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-14.1" remote="them" />
 
-    <!--  sony specific  -->
-    <project path="device/sony/common" name="LineageOS/android_device_sony_common" revision="cm-14.1" remote="github" />
-    <project path="vendor/sony" name="TheMuppets/proprietary_vendor_sony" revision="cm-14.1" remote="github" />
-    <project path="hardware/sony/thermanager" name="LineageOS/android_hardware_sony_thermanager" revision="cm-14.1" remote="github" />
-    <project path="external/stlport" name="LineageOS/android_external_stlport" revision="cm-14.1" remote="github" />
-    <project path="external/elfutils" name="LineageOS/android_external_elfutils" groups="pdk" revision="cm-14.1" remote="github" />
-    <!-- qcom specific -->
-    <project path="device/qcom/common" name="LineageOS/android_device_qcom_common" revision="cm-14.1" remote="github" />
-    <project path="device/qcom/sepolicy" name="LineageOS/android_device_qcom_sepolicy" revision="cm-14.1" remote="github" />
-    <!--  yuga specific  -->
-    <project path="device/sony/yuga" name="LNJ2/android_device_sony_yuga" revision="halium-7.1" remote="github" />
-    <project path="kernel/sony/apq8064" name="LNJ2/android_kernel_sony_apq8064" revision="halium-7.1" remote="github" />
-    <project path="device/sony/fusion3-common" name="LineageOS/android_device_sony_fusion3-common" revision="cm-14.1" remote="github" />
+	<project path="device/sony/common" name="android_device_sony_common" revision="cm-14.1" remote="los" />
+	<project path="device/sony/fusion3-common" name="android_device_sony_fusion3-common" revision="cm-14.1" remote="los" />
+	<project path="device/qcom/common" name="android_device_qcom_common" revision="cm-14.1" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" revision="cm-14.1" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
+	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
+	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
+	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>


### PR DESCRIPTION
Also added a replacement for hardware/qcom/media-caf/msm8960 that
removes unneeded Java code.