### PR TITLE
Update repositories for Fairphone 2

### DIFF
--- a/manifests/fairphone_FP2.xml
+++ b/manifests/fairphone_FP2.xml
@@ -1,7 +1,7 @@
 <manifest>
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
-  <project path="device/fairphone/FP2" name="z3ntu/android_device_fairphone_fp2" remote="hal" />
-  <project path="kernel/fairphone/msm8974" name="z3ntu/android_kernel_fairphone_msm8974" remote="hal" />
+  <project path="device/fairphone/FP2" name="Halium/android_device_fairphone_fp2" remote="hal" />
+  <project path="kernel/fairphone/msm8974" name="Halium/android_kernel_fairphone_msm8974" remote="hal" />
   <project path="vendor/fairphone/FP2" name="FairBlobs/proprietary_vendor_fairphone" remote="hal" />
 </manifest>


### PR DESCRIPTION
Fixes #11 
Kernel is still uploading to https://github.com/Halium/android_kernel_fairphone_msm8974, I'm planning to push the halium-5.1 branch from @peat-psuwit there too.

Note, that I didn't test anything, I'm just pushing my old branches that presumably worked at some point to the repository.