### PR TITLE
Add sony shinano common devices

### DIFF
--- a/manifests/sony_castor.xml
+++ b/manifests/sony_castor.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/castor" name="LNJ2/android_device_sony_castor" remote="hal" />
+	<project path="device/sony/castor_windy" name="android_device_sony_castor_windy" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_castor_windy.xml
+++ b/manifests/sony_castor_windy.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/castor_windy" name="android_device_sony_castor_windy" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_sirius.xml
+++ b/manifests/sony_sirius.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/sirius" name="android_device_sony_sirius" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_z3.xml
+++ b/manifests/sony_z3.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/z3" name="android_device_sony_z3" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_z3c.xml
+++ b/manifests/sony_z3c.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/z3c" name="android_device_sony_z3c" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_z3dual.xml
+++ b/manifests/sony_z3dual.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/z3dual" name="android_device_sony_z3dual" remote="los" />
+	<project path="device/sony/z3" name="android_device_sony_z3" remote="los" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/shinano-common" name="android_device_sony_shinano-common" remote="los" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>


### PR DESCRIPTION
This includes the devices:
 * Sony Xperia Z2 (sirius)
 * Sony Xperia Z2 Tablet (castor)
 * Sony Xperia Z2 Tablet WiFi (castor_windy)
 * Sony Xperia Z3 (leo, z3)
 * Sony Xperia Z3 Compact (aries, z3c)
 * Sony Xperia Z3 Dual-SIM (z3dual)

The scorpion and scorpion_windy devices were already added, but also belong to
the shinano common devices.

I tested all manifests, they clone and compile successfully.