### PR TITLE
Add motoroal msm8916-common devices

### DIFF
--- a/manifests/motorola_lux.xml
+++ b/manifests/motorola_lux.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <project path="device/motorola/harpia" name="android_device_motorola_harpia" remote="los" />
+  <project path="device/motorola/lux" name="android_device_motorola_lux" remote="los" />
   <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />

--- a/manifests/motorola_merlin.xml
+++ b/manifests/motorola_merlin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <project path="device/motorola/harpia" name="android_device_motorola_harpia" remote="los" />
+  <project path="device/motorola/merlin" name="android_device_motorola_merlin" remote="los" />
   <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />

--- a/manifests/motorola_osprey.xml
+++ b/manifests/motorola_osprey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <project path="device/motorola/harpia" name="android_device_motorola_harpia" remote="los" />
+  <project path="device/motorola/osprey" name="android_device_motorola_osprey" remote="los" />
   <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />

--- a/manifests/motorola_surnia.xml
+++ b/manifests/motorola_surnia.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <project path="device/motorola/harpia" name="android_device_motorola_harpia" remote="los" />
+  <project path="device/motorola/surnia" name="android_device_motorola_surnia" remote="los" />
   <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />


### PR DESCRIPTION
This includes the devices:
 * Motorola Moto G3 Turbo (merlin)
 * Motorola Moto E 2015 LTE (surnia)
 * Motorola Moto G 2015 (osprey)
 * Motorola Moto X Play (lux)

The Motorola Moto G4 Play also belongs to the msm8916-common platform, but is
already included. I only removed unnecessary `revision` attributes there.