### PR TITLE
[WIP] Add sony rhine common devices

### DIFF
--- a/manifests/sony_amami.xml
+++ b/manifests/sony_amami.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/amami" name="LNJ2/android_device_sony_amami" remote="hal" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/rhine-common" name="LNJ2/android_device_sony_rhine-common" remote="hal" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_honami.xml
+++ b/manifests/sony_honami.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/honami" name="LNJ2/android_device_sony_honami" remote="hal" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/rhine-common" name="LNJ2/android_device_sony_rhine-common" remote="hal" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_togari.xml
+++ b/manifests/sony_togari.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/togari" name="LNJ2/android_device_sony_togari" remote="hal" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/rhine-common" name="LNJ2/android_device_sony_rhine-common" remote="hal" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>

--- a/manifests/sony_togari_gpe.xml
+++ b/manifests/sony_togari_gpe.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<project path="device/sony/togari_gpe" name="LNJ2/android_device_sony_togari_gpe" remote="hal" />
+	<project path="device/sony/togari" name="LNJ2/android_device_sony_togari" remote="hal" />
+	<project path="kernel/sony/msm8974" name="LNJ2/android_kernel_sony_msm8974" remote="hal" />
+	<project path="device/sony/rhine-common" name="LNJ2/android_device_sony_rhine-common" remote="hal" />
+	<project path="device/sony/msm8974-common" name="android_device_sony_msm8974-common" remote="los" />
+	<project path="device/sony/common" name="android_device_sony_common" remote="los" />
+
+	<project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-13.0" remote="them" />
+
+	<project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+	<project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+
+	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" remote="los" />
+	<project path="hardware/sony/macaddrsetup" name="android_hardware_sony_macaddrsetup" remote="los" />
+
+	<project path="external/elfutils" name="android_external_elfutils" remote="los" />
+	<project path="external/stlport" name="android_external_stlport" remote="los" />
+	<project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
+</manifest>


### PR DESCRIPTION
#This includes the devices:
 * Sony Xperia Z1 (honami)
 * Sony Xperia Z1 Compact (amami)
 * Sony Xperia Z Ultra (togari)
 * Sony Xperia Z Ultra Google Play Edition (togari_gpe)

---

Currently there are still problems compiling the kernel... 😐 

```
arch/arm/mach-msm/built-in.o: In function `sony_init_gpiomux':
/media/lnj/lnjXdata/halium/7.1/kernel/sony/msm8974/arch/arm/mach-msm/sony_gpiomux.c:135: undefined reference to `gpiomux_arrange_all_qct_configs'
/media/lnj/lnjXdata/halium/7.1/kernel/sony/msm8974/Makefile:874: die Regel für Ziel „.tmp_vmlinux1“ scheiterte
make[1]: *** [.tmp_vmlinux1] Fehler 1
Makefile:130: die Regel für Ziel „sub-make“ scheiterte
make: *** [sub-make] Fehler 2
make: Verzeichnis „/media/lnj/lnjXdata/halium/7.1/kernel/sony/msm8974“ wird verlassen
ninja: build stopped: subcommand failed.
build/core/ninja.mk:151: die Regel für Ziel „ninja_wrapper“ scheiterte
make: *** [ninja_wrapper] Fehler 1
make: Verzeichnis „/media/lnj/lnjXdata/halium/7.1“ wird verlassen

#### make failed to build some targets (01:29 (mm:ss)) ####
```