### PR TITLE
Add samsung klte/hlte common devices

### DIFF
--- a/manifests/samsung_hlte.xml
+++ b/manifests/samsung_hlte.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/hlte" name="android_device_samsung_hlte" remote="los" />
+  <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_hltechn.xml
+++ b/manifests/samsung_hltechn.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/hltechn" name="android_device_samsung_hltechn" remote="los" />
+  <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_hltetmo.xml
+++ b/manifests/samsung_hltetmo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/hltetmo" name="android_device_samsung_hltetmo" remote="los" />
+  <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_klte.xml
+++ b/manifests/samsung_klte.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/klte" name="android_device_samsung_klte" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltechn.xml
+++ b/manifests/samsung_kltechn.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltechn" name="android_device_samsung_kltechn" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_klteduos.xml
+++ b/manifests/samsung_klteduos.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/klteduos" name="android_device_samsung_klteduos" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltedv.xml
+++ b/manifests/samsung_kltedv.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltedv" name="android_device_samsung_kltedv" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltekdi.xml
+++ b/manifests/samsung_kltekdi.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltekdi" name="android_device_samsung_kltekdi" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltekor.xml
+++ b/manifests/samsung_kltekor.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltekor" name="android_device_samsung_kltekor" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltespr.xml
+++ b/manifests/samsung_kltespr.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltespr" name="android_device_samsung_kltespr" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltesprsports.xml
+++ b/manifests/samsung_kltesprsports.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltesprsports" name="android_device_samsung_kltesprsports" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltetechnduo.xml
+++ b/manifests/samsung_kltetechnduo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltetechnduo" name="android_device_samsung_kltetechnduo" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_klteusc.xml
+++ b/manifests/samsung_klteusc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/klteusc" name="android_device_samsung_klteusc" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>

--- a/manifests/samsung_kltevzw.xml
+++ b/manifests/samsung_kltevzw.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/kltevzw" name="android_device_samsung_kltevzw" remote="los" />
+  <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
+  <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
+  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
+  <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
+  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
+</manifest>


### PR DESCRIPTION
This includes the devices:
 * Samsung Galaxy Note 3 LTE (N9005/P) (hlte)
 * Samsung Galaxy Note 3 (China) (hltechn)
 * Samsung Galaxy Note 3 LTE (N900T/V/W8) (hltetmo)
 * Samsung Galaxy S5 LTE (G900AZ/F/M/R4/R7/T/V/W8,S902L) (klte)
 * Samsung Galaxy S5 LTE (China) (G9006V/8V) (kltechn)
 * Samsung Galaxy S5 LTE Duos (G900FD/MD) (klteduos)
 * Samsung Galaxy S5 LTE (G900I/P) (kltedv)
 * Samsung Galaxy S5 LTE (SCL23) (kltekdi)
 * Samsung Galaxy S5 LTE (G900K/L/S) (kltekor)
 * Samsung Galaxy S5 Sprint (G900P) (kltespr)
 * Samsung Galaxy S5 Sport (kltesprsports)
 * Samsung Galaxy S5 China Dual-SIM (G9006W/G9008W/G9009W) (kltechnduo)
 * Samsung Galaxy S5 USC (G900R4/G900R7) (klteusc)
 * Samsung Galaxy S5 Verizon (G900V/S902L) (kltevzw)

Hello, Samsung - One mobile phone + one tablet = 14 different devices