### PR TITLE
Add manifest for potter

### DIFF
--- a/manifests/motorola_potter.xml
+++ b/manifests/motorola_potter.xml
@@ -7,12 +7,12 @@
     fetch="https://github.com/boulzordev"
     revision="cm-14.1" />
 
-  <project name="android_device_motorola_potter" path="device/motorola/potter" remote="usb" revision="halium-7.1" />
-  <project name="android_kernel_motorola_msm8953" path="kernel/motorola/msm8953" remote="usb" revision="halium-7.1" />
+  <project name="android_device_motorola_potter" path="device/motorola/potter" remote="usb" />
+  <project name="android_kernel_motorola_msm8953" path="kernel/motorola/msm8953" remote="usb" />
   <project name="android_vendor_motorola_potter" path="vendor/motorola/potter" remote="boulzordev" revision="master" />
-  <project name="android_device_qcom_common" path="device/qcom/common" remote="los" revision="cm-14.1" />
-  <project name="android_packages_resources_devicesettings" path="packages/resources/devicesettings" remote="los" revision="cm-14.1" />
-  <project name="android_external_bson" path="external/bson" remote="los" revision="cm-14.1" />
+  <project name="android_device_qcom_common" path="device/qcom/common" remote="los" />
+  <project name="android_packages_resources_devicesettings" path="packages/resources/devicesettings" remote="los"/>
+  <project name="android_external_bson" path="external/bson" remote="los"/>
   <project name="android_external_bluetooth_bluedroid" path="external/bluetooth/bluedroid" remote="los" revision="cm-12.1" />
-  <project name="android_device_qcom_sepolicy" path="device/qcom/sepolicy" remote="los" revision="cm-14.1" />
+  <project name="android_device_qcom_sepolicy" path="device/qcom/sepolicy" remote="los"/>
 </manifest>

--- a/manifests/motorola_potter.xml
+++ b/manifests/motorola_potter.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="usb"
+    fetch="https://github.com/universalsuperbox"
+    revision="halium-7.1" />
+  <remote name="boulzordev"
+    fetch="https://github.com/boulzordev"
+    revision="cm-14.1" />
+
+  <project name="android_device_motorola_potter" path="device/motorola/potter" remote="usb" revision="halium-7.1" />
+  <project name="android_kernel_motorola_msm8953" path="kernel/motorola/msm8953" remote="usb" revision="halium-7.1" />
+  <project name="android_vendor_motorola_potter" path="vendor/motorola/potter" remote="boulzordev" revision="master" />
+  <project name="android_device_qcom_common" path="device/qcom/common" remote="los" revision="cm-14.1" />
+  <project name="android_packages_resources_devicesettings" path="packages/resources/devicesettings" remote="los" revision="cm-14.1" />
+  <project name="android_external_bson" path="external/bson" remote="los" revision="cm-14.1" />
+  <project name="android_external_bluetooth_bluedroid" path="external/bluetooth/bluedroid" remote="los" revision="cm-12.1" />
+  <project name="android_device_qcom_sepolicy" path="device/qcom/sepolicy" remote="los" revision="cm-14.1" />
+</manifest>


### PR DESCRIPTION
Yes, really, it has to use bluedroid from cm12.1. It won't build without it in the tree.