### PR TITLE
Add Nexus 6P (angler)

### DIFF
--- a/huawei_angler.xml
+++ b/huawei_angler.xml
@@ -1,0 +1,5 @@
+<manifest>
+    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" revision="cm-14.1" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="los" />
+    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
+</manifest>

--- a/huawei_angler.xml
+++ b/huawei_angler.xml
@@ -1,5 +1,0 @@
-<manifest>
-    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" revision="cm-14.1" />
-    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="los" />
-    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
-</manifest>

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,5 +1,5 @@
 <manifest>
-    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" revision="cm-14.1" />
-    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="los" />
-    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
+    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="https://github.com/win8linux/android_kernel_huawei_angler" revision="halium-7.1" />
+    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="https://github.com/win8linux/proprietary_vendor_huawei" revision="halium-7.1" />
 </manifest>

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,5 +1,5 @@
 <manifest>
     <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" />
-    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="https://github.com/win8linux/android_kernel_huawei_angler" revision="halium-7.1" />
-    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="https://github.com/win8linux/proprietary_vendor_huawei" revision="halium-7.1" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="hal" revision="halium-7.1" />
+    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="hal" revision="halium-7.1" />
 </manifest>

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,0 +1,5 @@
+<manifest>
+    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" revision="cm-14.1" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="los" />
+    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
+</manifest>

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,5 +1,5 @@
 <manifest>
     <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" />
-    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="hal" />
+    <project path="kernel/huawei/angler" name="win8linux/android_kernel_huawei_angler" remote="hal" />
     <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
 </manifest>

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,5 +1,5 @@
 <manifest>
     <project path="device/huawei/angler" name="android_device_huawei_angler" remote="los" />
-    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="hal" revision="halium-7.1" />
-    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="hal" revision="halium-7.1" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="hal" />
+    <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
 </manifest>


### PR DESCRIPTION
As of the time of posting this, the system image fails to build.

Here's the output from `mka systemimage`:
```
make: Entering directory '/home/********/Public/Nexus6P/ports/code/Halium'
============================================
PLATFORM_VERSION_CODENAME=REL
PLATFORM_VERSION=7.1.1
LINEAGE_VERSION=14.1-20180204-UNOFFICIAL-angler
TARGET_PRODUCT=lineage_angler
TARGET_BUILD_VARIANT=userdebug
TARGET_BUILD_TYPE=release
TARGET_BUILD_APPS=
TARGET_ARCH=arm64
TARGET_ARCH_VARIANT=armv8-a
TARGET_CPU_VARIANT=cortex-a53
TARGET_2ND_ARCH=arm
TARGET_2ND_ARCH_VARIANT=armv7-a-neon
TARGET_2ND_CPU_VARIANT=cortex-a53.a57
HOST_ARCH=x86_64
HOST_2ND_ARCH=x86
HOST_OS=linux
HOST_OS_EXTRA=Linux-4.10.0-38-generic-x86_64-with-LinuxMint-18.3-sylvia
HOST_CROSS_OS=windows
HOST_CROSS_ARCH=x86
HOST_CROSS_2ND_ARCH=x86_64
HOST_BUILD_TYPE=release
BUILD_ID=NOF27B
OUT_DIR=/home/********/Public/Nexus6P/ports/code/Halium/out
============================================
Running kati to generate build-lineage_angler.ninja...
No need to regenerate ninja file
Starting build with ninja
ninja: Entering directory `.'
ninja: error: '/home/********/Public/Nexus6P/ports/code/Halium/out/host/linux-x86/framework/signapk.jar', needed by '/home/********/Public/Nexus6P/ports/code/Halium/out/target/product/angler/obj/APPS/HwSarControlService_intermediates/package.apk', missing and no known rule to make it
build/core/ninja.mk:151: recipe for target 'ninja_wrapper' failed
make: *** [ninja_wrapper] Error 1
make: Leaving directory '/home/********/Public/Nexus6P/ports/code/Halium'
```
However, building `hybris-boot` and the boot image are both successful.