### PR TITLE
Automatically refresh vendor repository

### DIFF
--- a/setup
+++ b/setup
@@ -31,4 +31,15 @@ else
 	# Synchronize new new sources
 	repo sync --network-only -c -j$JOBS -q
 	repo sync --local-only -c -j$JOBS -q
+
+	# Refresh the vendor repository so apks and jars are not copied
+	# For this to work, all apks and jars need to be removed from device/$vendor/$codename/proprietary-files.txt
+
+	SETUP_MAKEFILES=$REPO_ROOT/device/*/$DEVICE/setup-makefiles.sh
+
+	if [ -f $SETUP_MAKEFILES ]; then
+		echo "I: Refreshing vendor repository"
+		chmod +x $SETUP_MAKEFILES
+		$SETUP_MAKEFILES
+	fi
 fi

--- a/setup
+++ b/setup
@@ -35,11 +35,10 @@ else
 	# Refresh the vendor repository so apks and jars are not copied
 	# For this to work, all apks and jars need to be removed from device/$vendor/$codename/proprietary-files.txt
 
-	SETUP_MAKEFILES=$REPO_ROOT/device/*/$DEVICE/setup-makefiles.sh
+	DEVICE_TREE=$REPO_ROOT/device/*/$DEVICE
 
-	if [ -f $SETUP_MAKEFILES ]; then
+	if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
 		echo "I: Refreshing vendor repository"
-		chmod +x $SETUP_MAKEFILES
-		$SETUP_MAKEFILES
+		(cd $DEVICE_TREE; ./setup-makefiles.sh)
 	fi
 fi


### PR DESCRIPTION
apks now only need to be removed from device/$vendor/$codename/proprietary-files.txt. This makes forking the vendor repository unneccesary, only the device tree needs to be changed.

Probably fixes #21