### PR TITLE
samsung: Use hardware and qcom-commmon from Halium org.

### DIFF
--- a/manifests/samsung_herolte.xml
+++ b/manifests/samsung_herolte.xml
@@ -2,7 +2,7 @@
 <manifest>
     <project path="device/samsung/herolte" name="android_device_samsung_herolte" remote="los" />
     <project path="device/samsung/hero-common" name="android_device_samsung_hero-common" remote="los" />
-    <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+    <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
     <project path="hardware/samsung_slsi-cm/exynos" name="android_hardware_samsung_slsi-cm_exynos" remote="los" />
     <project path="hardware/samsung_slsi-cm/exynos5" name="android_hardware_samsung_slsi-cm_exynos5" remote="los" />
     <project path="hardware/samsung_slsi-cm/exynos8890" name="android_hardware_samsung_slsi-cm_exynos8890" remote="los" />

--- a/manifests/samsung_hlte.xml
+++ b/manifests/samsung_hlte.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/hlte" name="android_device_samsung_hlte" remote="los" />
   <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_hltechn.xml
+++ b/manifests/samsung_hltechn.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/hltechn" name="android_device_samsung_hltechn" remote="los" />
   <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_hltetmo.xml
+++ b/manifests/samsung_hltetmo.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/hltetmo" name="android_device_samsung_hltetmo" remote="los" />
   <project path="device/samsung/hlte-common" name="LNJ2/android_device_samsung_hlte-common" remote="hal" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_klte.xml
+++ b/manifests/samsung_klte.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/klte" name="android_device_samsung_klte" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltechn.xml
+++ b/manifests/samsung_kltechn.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltechn" name="android_device_samsung_kltechn" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_klteduos.xml
+++ b/manifests/samsung_klteduos.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/klteduos" name="android_device_samsung_klteduos" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltedv.xml
+++ b/manifests/samsung_kltedv.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltedv" name="android_device_samsung_kltedv" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltekdi.xml
+++ b/manifests/samsung_kltekdi.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltekdi" name="android_device_samsung_kltekdi" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltekor.xml
+++ b/manifests/samsung_kltekor.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltekor" name="android_device_samsung_kltekor" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltespr.xml
+++ b/manifests/samsung_kltespr.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltespr" name="android_device_samsung_kltespr" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltesprsports.xml
+++ b/manifests/samsung_kltesprsports.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltesprsports" name="android_device_samsung_kltesprsports" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltetechnduo.xml
+++ b/manifests/samsung_kltetechnduo.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltetechnduo" name="android_device_samsung_kltetechnduo" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_klteusc.xml
+++ b/manifests/samsung_klteusc.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/klteusc" name="android_device_samsung_klteusc" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>

--- a/manifests/samsung_kltevzw.xml
+++ b/manifests/samsung_kltevzw.xml
@@ -3,11 +3,11 @@
   <project path="device/samsung/kltevzw" name="android_device_samsung_kltevzw" remote="los" />
   <project path="device/samsung/klte-common" name="android_device_samsung_klte-common" remote="los" />
   <project path="device/samsung/msm8974-common" name="android_device_samsung_msm8974-common" remote="los" />
-  <project path="device/samsung/qcom-common" name="LNJ2/android_device_samsung_qcom-common" remote="hal" />
+  <project path="device/samsung/qcom-common" name="Halium/android_device_samsung_qcom-common" remote="hal" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="kernel/samsung/msm8974" name="LNJ2/android_kernel_samsung_msm8974" remote="hal" />
-  <project path="hardware/samsung" name="LNJ2/android_hardware_samsung" remote="hal" />
+  <project path="hardware/samsung" name="Halium/android_hardware_samsung" remote="hal" />
   <project path="vendor/samsung" name="proprietary_vendor_samsung" remote="them" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
 </manifest>


### PR DESCRIPTION
These repositories were located at https://github.com/LNJ2/*, but were moved to
the Halium organisation since near every samsung device will need the fixes
included in these repositories.