### PR TITLE
motorola-msm8916-common: Use kernel & device tree from Halium

### DIFF
--- a/manifests/motorola_harpia.xml
+++ b/manifests/motorola_harpia.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project path="device/motorola/harpia" name="android_device_motorola_harpia" remote="los" />
-  <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
+  <project path="device/motorola/msm8916-common" name="Halium/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/sony/boringssl-compat" name="android_external_sony_boringssl-compat" remote="los" />
-  <project path="kernel/motorola/msm8916" name="LNJ2/android_kernel_motorola_msm8916" remote="hal" />
+  <project path="kernel/motorola/msm8916" name="Halium/android_kernel_motorola_msm8916" remote="hal" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="los" />
   <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
 </manifest>

--- a/manifests/motorola_lux.xml
+++ b/manifests/motorola_lux.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project path="device/motorola/lux" name="android_device_motorola_lux" remote="los" />
-  <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
+  <project path="device/motorola/msm8916-common" name="Halium/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/sony/boringssl-compat" name="android_external_sony_boringssl-compat" remote="los" />
-  <project path="kernel/motorola/msm8916" name="LNJ2/android_kernel_motorola_msm8916" remote="hal" />
+  <project path="kernel/motorola/msm8916" name="Halium/android_kernel_motorola_msm8916" remote="hal" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="los" />
   <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
 </manifest>

--- a/manifests/motorola_merlin.xml
+++ b/manifests/motorola_merlin.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project path="device/motorola/merlin" name="android_device_motorola_merlin" remote="los" />
-  <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
+  <project path="device/motorola/msm8916-common" name="Halium/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/sony/boringssl-compat" name="android_external_sony_boringssl-compat" remote="los" />
-  <project path="kernel/motorola/msm8916" name="LNJ2/android_kernel_motorola_msm8916" remote="hal" />
+  <project path="kernel/motorola/msm8916" name="Halium/android_kernel_motorola_msm8916" remote="hal" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="los" />
   <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
 </manifest>

--- a/manifests/motorola_osprey.xml
+++ b/manifests/motorola_osprey.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project path="device/motorola/osprey" name="android_device_motorola_osprey" remote="los" />
-  <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
+  <project path="device/motorola/msm8916-common" name="Halium/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/sony/boringssl-compat" name="android_external_sony_boringssl-compat" remote="los" />
-  <project path="kernel/motorola/msm8916" name="LNJ2/android_kernel_motorola_msm8916" remote="hal" />
+  <project path="kernel/motorola/msm8916" name="Halium/android_kernel_motorola_msm8916" remote="hal" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="los" />
   <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
 </manifest>

--- a/manifests/motorola_surnia.xml
+++ b/manifests/motorola_surnia.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <project path="device/motorola/surnia" name="android_device_motorola_surnia" remote="los" />
-  <project path="device/motorola/msm8916-common" name="LNJ2/android_device_motorola_msm8916-common" remote="hal" />
+  <project path="device/motorola/msm8916-common" name="Halium/android_device_motorola_msm8916-common" remote="hal" />
   <project path="device/motorola/qcom-common" name="android_device_motorola_qcom-common" remote="los" />
   <project path="device/qcom/common" name="android_device_qcom_common" remote="los" />
   <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/sony/boringssl-compat" name="android_external_sony_boringssl-compat" remote="los" />
-  <project path="kernel/motorola/msm8916" name="LNJ2/android_kernel_motorola_msm8916" remote="hal" />
+  <project path="kernel/motorola/msm8916" name="Halium/android_kernel_motorola_msm8916" remote="hal" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="los" />
   <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
 </manifest>


### PR DESCRIPTION
This replaces the kernel and common device tree repositories of the motorola
msm8916-common devices to the ones from Halium. They were moved from @lnj2 to
@halium on GitHub.