### PR TITLE
fusion3: Remove hardware_qcom_media repo replacement

### DIFF
--- a/manifests/sony_dogo.xml
+++ b/manifests/sony_dogo.xml
@@ -10,6 +10,4 @@
 	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
 	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
 	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
-	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
-	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>

--- a/manifests/sony_odin.xml
+++ b/manifests/sony_odin.xml
@@ -10,6 +10,4 @@
 	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
 	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
 	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
-	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
-	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>

--- a/manifests/sony_pollux.xml
+++ b/manifests/sony_pollux.xml
@@ -11,6 +11,4 @@
 	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
 	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
 	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
-	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
-	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>

--- a/manifests/sony_pollux_windy.xml
+++ b/manifests/sony_pollux_windy.xml
@@ -11,6 +11,4 @@
 	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
 	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
 	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
-	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
-	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>

--- a/manifests/sony_yuga.xml
+++ b/manifests/sony_yuga.xml
@@ -10,6 +10,4 @@
 	<project path="external/stlport" name="android_external_stlport" revision="cm-14.1" remote="los" />
 	<project path="external/elfutils" name="android_external_elfutils" groups="pdk" revision="cm-14.1" remote="los" />
 	<project path="hardware/sony/thermanager" name="android_hardware_sony_thermanager" revision="cm-14.1" remote="los" />
-	<remove-project path="hardware/qcom/media-caf/msm8960" name="android_hardware_qcom_media" revision="cm-14.1-caf-8960" remote="los" />
-	<project path="hardware/qcom/media-caf/msm8960" name="LNJ2/android_hardware_qcom_media" groups="qcom" revision="halium-7.1-caf-8960" remote="hal" />
 </manifest>


### PR DESCRIPTION
The replacments are not needed anymore since this commit in the main manifest:
https://github.com/Halium/android/commit/aa8686a393886e9b727cb278da774ef2aa634b7e