### PR TITLE
Setup: Unify coding style & more automation for common folders and fstab

### DIFF
--- a/setup
+++ b/setup
@@ -14,8 +14,9 @@ fi
 if ! [ -f $DEVICES_ROOT/manifests/*_$DEVICE.xml ]; then
     echo "The given device is not supported. :("
 else
+    VENDOR=$(basename $DEVICES_ROOT/manifests/*_$DEVICE.xml | cut -d "_" -f1)
     echo "*****************************************"
-    echo "Configuring for device $DEVICE"
+    echo "I: Configuring for device $VENDOR"_"$DEVICE"
     echo "*****************************************"
 
     # Test if there is already a device configured and the folder exists
@@ -26,19 +27,64 @@ else
     fi
 
     # Link the device manifest to the local_manifests folder
-    ln $DEVICES_ROOT/manifests/*_$DEVICE.xml $REPO_ROOT/.repo/local_manifests/device.xml
+    ln $DEVICES_ROOT/manifests/$VENDOR"_"$DEVICE.xml $REPO_ROOT/.repo/local_manifests/device.xml
 
     # Synchronize new new sources
     repo sync --network-only -c -j$JOBS -q
     repo sync --local-only -c -j$JOBS -q
 
-    # Refresh the vendor repository so apks and jars are not copied
-    # For this to work, all apks and jars will be removed by the grep command below that will strip them from the device/$vendor/$codename/proprietary-*.txt files
+    # Refresh the device & common repositories so apks and jars are not copied
+    # For this to work, all apks and jars need to be removed from device/$VENDOR/$DEVICE/*proprietary-files*.txt and device/$VENDOR/$DEVICE_COMMON/*proprietary-files*.txt
 
-    DEVICE_TREE=$REPO_ROOT/device/*/$DEVICE
+    #A device can have multiple commons as it seems, so we store them in DEVICE_COMMON_TEMP and loop through them later.
+    DEVICE_COMMON_TEMP=$(ls -d $REPO_ROOT/device/$VENDOR/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev )
+    DEVICE_TREE=$REPO_ROOT/device/$VENDOR/$DEVICE
 
     if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
-        echo "I: Refreshing vendor repository"
-        (cd $DEVICE_TREE; for i in `find . -name "proprietary-*.txt"`; do grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i > $i".tmp" && mv $i".tmp" $i; done; ./setup-makefiles.sh)
+        echo "*******************************************"
+        echo "I: Refreshing device vendor repository: /device/"$VENDOR/$DEVICE
+        (cd $DEVICE_TREE; for i in `find . -name "*proprietary-*.txt"`; do echo "I: Processing proprietary blob file: "$i; grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i > $i".tmp" && mv $i".tmp" $i; done; ./setup-makefiles.sh; )
+    echo "*******************************************"
+    fi
+
+    #Since we don't use SELinux we want to make sure we remove the ",context=u....:s0" from the fstab file(s) in the $DEVICE folder so we can mount the partitions without issues
+    cd $DEVICE_TREE && for j in `find . -name "fstab.*"`; do echo "I: Processing fstab file: "$j; sed -r 's/([,][c][o][n][t][e][x][t][=].*[:][s][0])//' $j > $j".tmp" && mv $j".tmp" $j; done;
+
+    #Loop through values in $DEVICE_COMMON_TEMP
+    if [ -n "$DEVICE_COMMON_TEMP" ]; then
+        echo "*******************************************"
+        for k in $DEVICE_COMMON_TEMP;
+            do echo "I: Procession device vendor common folder: /device/"$VENDOR/$k; COMMON_TREE=$REPO_ROOT/device/$VENDOR/$k;
+
+            #We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or $PLATFORM_COMMON available for setup-makefiles.sh in the common repository, therefore export them.
+            export VENDOR;
+            export DEVICE;
+            DEVICE_COMMON_HOLDER=$DEVICE_COMMON;
+            DEVICE_COMMON=${DEVICE_COMMON:=$k};
+            export DEVICE_COMMON=$DEVICE_COMMON;
+            PLATFORM_COMMON_HOLDER=$PLATFORM_COMMON;
+            PLATFORM_COMMON=${PLATFORM_COMMON:=$DEVICE_COMMON}
+            export PLATFORM_COMMON=$PLATFORM_COMMON;
+
+            if [ -f $COMMON_TREE/setup-makefiles.sh ]; then
+                (cd $COMMON_TREE; for l in `find . -name "*proprietary-*.txt"`; do echo "I: Processing proprietary blob file: "$l; grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $l > $l".tmp" && mv $l".tmp" $l; done; ./setup-makefiles.sh; )
+            fi
+
+            #Since we don't use SELinux we want to make sure we remove the ",context=u....:s0" from the fstab file(s) in the $DEVICE_COMMON folder so we can mount the partitions without issues
+            cd $COMMON_TREE && for m in `find . -name "fstab.*"`; do echo "I: Processing fstab file: "$m; sed -r 's/([,][c][o][n][t][e][x][t][=].*[:][s][0])//' $m > $m".tmp" && mv $m".tmp" $m; done;
+            #Since we can have multiple common repos we need to make sure to set back the original values in case they exist. Otherwise unset the value.
+            if [ -n "$DEVICE_COMMON_HOLDER" ]; then
+                DEVICE_COMMON=$DEVICE_COMMON_HOLDER;
+            else
+                unset DEVICE_COMMON
+            fi
+            if [ -n "$PLATFORM_COMMON_HOLDER" ]; then
+                PLATFORM_COMMON=$PLATFORM_COMMON_HOLDER;
+            else
+                unset PLATFORM_COMMON
+            fi
+            echo "*******************************************"
+        done
+    echo "*******************************************"
     fi
 fi

--- a/setup
+++ b/setup
@@ -7,38 +7,38 @@ DEVICES_ROOT="$(dirname "$(readlink -f "${0}")")"
 REPO_ROOT="${DEVICES_ROOT}/../.."
 
 if [ -z $DEVICE ]; then
-	echo "Please specify a device codename"
-	exit 0
+    echo "Please specify a device codename"
+    exit 0
 fi
 
 if ! [ -f $DEVICES_ROOT/manifests/*_$DEVICE.xml ]; then
-	echo "The given device is not supported. :("
+    echo "The given device is not supported. :("
 else
-	echo "*****************************************"
-	echo "Configuring for device $DEVICE"
-	echo "*****************************************"
+    echo "*****************************************"
+    echo "Configuring for device $DEVICE"
+    echo "*****************************************"
 
-	# Test if there is already a device configured and the folder exists
-	if [ -f $REPO_ROOT/.repo/local_manifests/device.xml ]; then
-		rm $REPO_ROOT/.repo/local_manifests/device.xml
-	elif ! [ -d $REPO_ROOT/.repo/local_manifests/ ]; then
-		mkdir $REPO_ROOT/.repo/local_manifests/
-	fi
+    # Test if there is already a device configured and the folder exists
+    if [ -f $REPO_ROOT/.repo/local_manifests/device.xml ]; then
+        rm $REPO_ROOT/.repo/local_manifests/device.xml
+    elif ! [ -d $REPO_ROOT/.repo/local_manifests/ ]; then
+        mkdir $REPO_ROOT/.repo/local_manifests/
+    fi
 
-	# Link the device manifest to the local_manifests folder
-	ln $DEVICES_ROOT/manifests/*_$DEVICE.xml $REPO_ROOT/.repo/local_manifests/device.xml
+    # Link the device manifest to the local_manifests folder
+    ln $DEVICES_ROOT/manifests/*_$DEVICE.xml $REPO_ROOT/.repo/local_manifests/device.xml
 
-	# Synchronize new new sources
-	repo sync --network-only -c -j$JOBS -q
-	repo sync --local-only -c -j$JOBS -q
+    # Synchronize new new sources
+    repo sync --network-only -c -j$JOBS -q
+    repo sync --local-only -c -j$JOBS -q
 
-	# Refresh the vendor repository so apks and jars are not copied
-	# For this to work, all apks and jars will be removed by the grep command below that will strip them from the device/$vendor/$codename/proprietary-*.txt files
+    # Refresh the vendor repository so apks and jars are not copied
+    # For this to work, all apks and jars will be removed by the grep command below that will strip them from the device/$vendor/$codename/proprietary-*.txt files
 
-	DEVICE_TREE=$REPO_ROOT/device/*/$DEVICE
+    DEVICE_TREE=$REPO_ROOT/device/*/$DEVICE
 
-	if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
-		echo "I: Refreshing vendor repository"
-		(cd $DEVICE_TREE; for i in `find . -name "proprietary-*.txt"`; do grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i > $i".tmp" && mv $i".tmp" $i; done; ./setup-makefiles.sh)
-	fi
+    if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
+        echo "I: Refreshing vendor repository"
+        (cd $DEVICE_TREE; for i in `find . -name "proprietary-*.txt"`; do grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i > $i".tmp" && mv $i".tmp" $i; done; ./setup-makefiles.sh)
+    fi
 fi


### PR DESCRIPTION
* Quite often large manufacturers like Sony, Motorola, Samsung etc make multiple variants of a phone which share common repo's. We often need to patch those to remove the apk and jar files. This update will take care of that.

* Remove the context= lines from fstab files since these are for SELinux
which we don't support.

* Allow for additional proprietary file names to be covered such as
common-proprietary-files.txt

* Add some more logging

*Move from tabs to 4 spaces since the manifests use the same.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>