### PR TITLE
Update chaozu manifest

### DIFF
--- a/manifests/bq_chaozu.xml
+++ b/manifests/bq_chaozu.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project path="device/bq/chaozu" name="JBBgameich/android_device_bq_chaozu" remote="hal" />
+    <project path="device/bq/chaozu" name="Halium/android_device_bq_chaozu" remote="hal" />
+    <project path="device/bq/msm8937-common" name="Halium/android_device_bq_msm8937-common" remote="hal" />
 
-    <project path="kernel/bq/msm8937" name="Halium/android_kernel_bq_msm8937" remote="hal" revision="halium-7.1-chaozu" />
+    <project path="kernel/bq/msm8937" name="Halium/android_kernel_bq_msm8937" remote="hal" />
 
-    <project path="vendor/bq" name="JBBgameich/proprietary_vendor_bq" revision="cm-14.1" remote="hal" />
+    <project path="vendor/bq" name="proprietary_vendor_bq" revision="cm-14.1" remote="them" />
 
     <!-- fixes -->
     <remove-project path="hardware/qcom/audio-caf/msm8937" name="android_hardware_qcom_audio" />


### PR DESCRIPTION
chaozu got upstream support by LineageOS, so quite a few things can be rebased or moved to upstream.