### PR TITLE
Add Xiaomi A1 (tissot)

### DIFF
--- a/manifests/xiaomi_tissot.xml
+++ b/manifests/xiaomi_tissot.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <project path="device/xiaomi/tissot" name="herrie82/android_device_xiaomi_tissot" remote="hal" revision="cm-14.1" />
+
+    <project path="kernel/xiaomi/msm8953" name="herrie82/tissot" remote="hal" revision="tissot-o-oss" />
+
+    <project path="vendor/xiaomi" name="herrie82/proprietary_vendor_xiaomi-1" remote="hal" revision="cm-14.1" />
+</manifest>


### PR DESCRIPTION
Add Xiaomi A1 (tissot) support.

Unfortunately the device and vendor repos needed quite some work before they were useful. Patches have been sent upstream to tissot-dev, however seems it's not very active, so linking my own repos for now.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>