### PR TITLE
Automate removal of CMAction, cmaction, LineageAction, KeyHandler and…

### DIFF
--- a/setup
+++ b/setup
@@ -68,6 +68,18 @@ else
         sed -r 's/(,context=.*:s0)//' $j >$j".tmp" && mv $j".tmp" $j
     done
 
+    # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
+    # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
+    cd $DEVICE_TREE
+    echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$DEVICE"
+    rm -rf cmactions
+    rm -rf CMActions
+    rm -rf LineageActions
+    rm -rf doze
+    rm -rf Doze
+    rm -rf keyhandler
+    rm -rf KeyHandler
+
     # Loop through values in $DEVICE_COMMON_TEMP
     if [ -n "$DEVICE_COMMON_TEMP" ]; then
         for k in $DEVICE_COMMON_TEMP; do
@@ -102,6 +114,19 @@ else
                 echo "I: Processing fstab file: device/$VENDOR/$m"
                 sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
             done
+
+            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
+            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
+            cd $DEVICE_COMMON_TREE
+            echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
+            rm -rf cmactions
+            rm -rf CMActions
+            rm -rf LineageActions
+            rm -rf doze
+            rm -rf Doze
+            rm -rf keyhandler
+            rm -rf KeyHandler
+
             # Since we can have multiple common repos we need to make sure to set
             # back the original values in case they exist. Otherwise unset the value.
             if [ -n "$DEVICE_COMMON_HOLDER" ]; then
@@ -151,6 +176,19 @@ else
                 echo "I: Processing fstab file: device/$VENDOR/$k/$m"
                 sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
             done
+
+            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
+            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
+            cd $VENDOR_COMMON_TREE
+            echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
+            rm -rf cmactions
+            rm -rf CMActions
+            rm -rf LineageActions
+            rm -rf doze
+            rm -rf Doze
+            rm -rf keyhandler
+            rm -rf KeyHandler
+
             # Since we can have multiple common repos we need to make sure to set
             # back the original values in case they exist. Otherwise unset the value.
             if [ -n "$DEVICE_COMMON_HOLDER" ]; then

--- a/setup
+++ b/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 function removeUnneededFolders {
-rm -rf [Cc][Mm]actions
-rm -rf [Ll]inage[Aa]ctions
-rm -rf [Dd]oze
-rm -rf [Kk]ey[Hh]andler
+    rm -rf [Cc][Mm]actions
+    rm -rf [Ll]inage[Aa]ctions
+    rm -rf [Dd]oze
+    rm -rf [Kk]ey[Hh]andler
 }
 
 DEVICE=${1:=${DEVICE}}

--- a/setup
+++ b/setup
@@ -44,6 +44,14 @@ else
     # DEVICE_COMMON_TEMP and loop through them later.
     DEVICE_COMMON_TEMP=$(ls -d $REPO_ROOT/device/$VENDOR/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev)
     VENDOR_COMMON_TEMP=$(ls -d $REPO_ROOT/vendor/$VENDOR/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev)
+
+    # OnePlus uses the device/oppo/common instead of expected device/oneplus/common for some targets.
+    # We use a small workaround in order to catch these as well.
+    if [ $VENDOR="oneplus" ]; then
+        DEVICE_COMMON_TEMP2=$(ls -d $REPO_ROOT/device/oppo/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev)
+        VENDOR2="oppo"
+    fi
+
     DEVICE_TREE=$REPO_ROOT/device/$VENDOR/$DEVICE
     VENDOR_TREE=$REPO_ROOT/vendor/$VENDOR
 
@@ -139,6 +147,26 @@ else
             else
                 unset PLATFORM_COMMON
             fi
+        done
+    fi
+
+    # Loop through values in $DEVICE_COMMON_TEMP2 for certain OnePlus target
+    if [ -n "$DEVICE_COMMON_TEMP2" ]; then
+        for k in $DEVICE_COMMON_TEMP2; do
+            echo "I: Procession device vendor common folder: device/$VENDOR2/$k"
+            DEVICE_COMMON_TREE2=$REPO_ROOT/device/$VENDOR2/$k
+
+            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
+            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
+            cd $DEVICE_COMMON_TREE2
+            echo "I: Removing components relying on SettingsLib from: device/$VENDOR2/$k"
+            rm -rf cmactions
+            rm -rf CMActions
+            rm -rf LineageActions
+            rm -rf doze
+            rm -rf Doze
+            rm -rf keyhandler
+            rm -rf KeyHandler
         done
     fi
 

--- a/setup
+++ b/setup
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+function removeUnneededFolders {
+rm -rf [Cc][Mm]actions
+rm -rf [Ll]inage[Aa]ctions
+rm -rf [Dd]oze
+rm -rf [Kk]ey[Hh]andler
+}
+
 DEVICE=${1:=${DEVICE}}
 JOBS=${JOBS:=12}
 ARGS=($@)
@@ -80,13 +87,7 @@ else
     # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
     cd $DEVICE_TREE
     echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$DEVICE"
-    rm -rf cmactions
-    rm -rf CMActions
-    rm -rf LineageActions
-    rm -rf doze
-    rm -rf Doze
-    rm -rf keyhandler
-    rm -rf KeyHandler
+    removeUnneededFolders
 
     # Loop through values in $DEVICE_COMMON_TEMP
     if [ -n "$DEVICE_COMMON_TEMP" ]; then
@@ -127,13 +128,7 @@ else
             # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
             cd $DEVICE_COMMON_TREE
             echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
-            rm -rf cmactions
-            rm -rf CMActions
-            rm -rf LineageActions
-            rm -rf doze
-            rm -rf Doze
-            rm -rf keyhandler
-            rm -rf KeyHandler
+            removeUnneededFolders
 
             # Since we can have multiple common repos we need to make sure to set
             # back the original values in case they exist. Otherwise unset the value.
@@ -160,13 +155,7 @@ else
             # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
             cd $DEVICE_COMMON_TREE2
             echo "I: Removing components relying on SettingsLib from: device/$VENDOR2/$k"
-            rm -rf cmactions
-            rm -rf CMActions
-            rm -rf LineageActions
-            rm -rf doze
-            rm -rf Doze
-            rm -rf keyhandler
-            rm -rf KeyHandler
+            removeUnneededFolders
         done
     fi
 
@@ -209,13 +198,7 @@ else
             # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
             cd $VENDOR_COMMON_TREE
             echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
-            rm -rf cmactions
-            rm -rf CMActions
-            rm -rf LineageActions
-            rm -rf doze
-            rm -rf Doze
-            rm -rf keyhandler
-            rm -rf KeyHandler
+            removeUnneededFolders
 
             # Since we can have multiple common repos we need to make sure to set
             # back the original values in case they exist. Otherwise unset the value.


### PR DESCRIPTION
… Doze

CMAction, LineageAction, KeyHandler and Doze all use SettingsLib which
we don't provide, so delete these folders completely so they don't get
build and we need less forking and patching of device repos.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>