### PR TITLE
Onyx.xml: Fix kernel repo

### DIFF
--- a/manifests/oneplus_onyx.xml
+++ b/manifests/oneplus_onyx.xml
@@ -4,7 +4,7 @@
 
     <project path="device/oppo/common" name="android_device_oppo_common" remote="los" />
 
-    <project path="kernel/oneplus/onyx" name="corpuscle/android_kernel_oneplus_onyx" remote="hal" revision="luneos/cm-14.1-wip" />
+    <project path="kernel/oneplus/onyx" name="android_kernel_oneplus_onyx" remote="los" />
 
     <project path="vendor/oneplus" name="proprietary_vendor_oneplus" remote="them" />
 </manifest>


### PR DESCRIPTION
Actually, please let us use the up to date LineageOS kernel directly.
My work-in-progress variant does not necessarily build with the Halium toolchain. It does now, but it didn't.