### PR TITLE
oneplus_onyx: Switch to corpuscle's device repo to fix issue with sys…

### DIFF
--- a/manifests/oneplus_onyx.xml
+++ b/manifests/oneplus_onyx.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project path="device/oneplus/onyx" name="android_device_oneplus_onyx" remote="los" />
+    <project path="device/oneplus/onyx" name="corpuscle/android_device_oneplus_onyx" remote="hal" revision="cm-14.1" />
 
     <project path="device/oppo/common" name="android_device_oppo_common" remote="los" />
 


### PR DESCRIPTION
…tem.prop

system.prop has incorrect values which cause issues in LuneOS. We currently patch this during our Halium build with a nasty patching mechanism, but it's better to include it directly in the build, so other OS-es can also benefit so our nasty patching mechanism.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>