### PR TITLE
Add Device Sony Z3+ (Z4) Ivy derived from an updated Sony Z5 (sumire) config

### DIFF
--- a/manifests/sony_ivy.xml
+++ b/manifests/sony_ivy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project path="device/sony/sumire" name="ubports/android_device_sony_sumire" remote="hal" />
+    <project path="device/sony/ivy" name="ubports/android_device_sony_ivy" remote="hal" />
     <project path="device/sony/kitakami-common" name="ubports/android_device_sony_kitakami-common" remote="hal" />
     <project path="device/sony/common" name="android_device_sony_common" remote="los" />
 


### PR DESCRIPTION
This is essentially the same as the Sony Z5 port - It uses the same kernel with updated apparmor and an adapted kernel config.