### PR TITLE
Add Moto Z Play (addison)

### DIFF
--- a/manifests/motorola_addison.xml
+++ b/manifests/motorola_addison.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="NotKit"
+        fetch="https://github.com/NotKit"
+        revision="halium-7.1" />
+
+    <project path="device/motorola/addison" name="android_device_motorola_addison" remote="NotKit" />
+
+    <project path="kernel/motorola/msm8953" name="android_kernel_motorola_msm8953" remote="NotKit" />
+
+    <project path="vendor/motorola" name="proprietary_vendor_motorola" remote="them" />
+</manifest>


### PR DESCRIPTION
The device is tested to boot into UBPorts rootfs, but currently requires some hacks for halium-boot due to using F2FS and having console=null kernel cmdline argument coming from bootloader.