### PR TITLE
suzu: Update device manifest

### DIFF
--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -9,9 +9,8 @@
 
   <!-- project path="device/sample" name="device/sample" revision="nougat-mr1-release" remote="aosp" / -->
   <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1" remote="beidl" />
-  <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1" remote="beidl" />
-  <project path="device/sony/common" name="device-sony-common" revision="n-mr1" remote="beidl" />
-  <!-- project path="device/sony/sepolicy" name="device-sony-sepolicy" revision="n-mr1" remote="beidl" / -->
+  <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
+  <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
   <project path="kernel/sony/suzu" name="device-kernel-suzu" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
   <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" revision="master" remote="sony" />
   <project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-14.1" remote="them" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -12,7 +12,7 @@
   <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
-  <project path="kernel/sony/suzu" name="device-kernel-suzu" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
+  <project path="kernel/sony/suzu" name="device-kerne-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -15,6 +15,7 @@
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
     
+    <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -4,18 +4,34 @@
   <remote name="sony" fetch="https://github.com/sonyxperiadev" />
   <remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
 
-  <!-- remove-project path="system/sepolicy" name="android_system_sepolicy" / -->
   <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
+  <remove-project path="bionic" name="Halium/android_bionic" />
+  <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
+  <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
 
-  <!-- project path="device/sample" name="device/sample" revision="nougat-mr1-release" remote="aosp" / -->
   <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1" remote="beidl" />
   <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
   <project path="kernel/sony/suzu" name="device-kernel-suzu" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
-  <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" revision="master" remote="sony" />
-  <project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-14.1" remote="them" />
+  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+  <project path="bionic" name="android_bionic" revision="halium-7.1" remote="beidl" />
+  
   <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
   <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
-  <project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.6.3.r1" />
-
+  <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />
+  <project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="master" />
+  <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="master" />
+  <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="master" />
+  <project path="vendor/qcom/opensource/fm" name="vendor-qcom-opensource-fm" groups="device" remote="sony" revision="master" />
+  <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="n-mr1" />
+  <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="master" />
+  <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
+  <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="android-7.1.1_r55" />
+  <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
+  <project path="vendor/oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
+  <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
+  <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="android-7.1.1_r55" />
+  <project path="vendor/oss/json-c" name="json-c" groups="device" remote="sony" revision="master" />
 </manifest>

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -7,6 +7,7 @@
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="system/sepolicy" name="android_system_sepolicy" />
+    <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
     
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
     <project path="system/sepolicy" name="android_system_sepolicy" remote="beidl" revision="halium-7.1" />
@@ -20,6 +21,9 @@
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
 
+    <project path="external/libnfc-nci" name="platform/external/libnfc-nci" groups="pdk" remote="aosp" />
+    <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" groups="pdk" remote="aosp" />
+
     <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
     <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="nxp" revision="master" />
     <project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="master" />
@@ -28,6 +32,7 @@
     <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="n-mr1" />
     <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="master" />
     <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
+    <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="master" />
     <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="android-7.1.1_r55" />
     <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
     <project path="vendor/oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -5,7 +5,6 @@
   <remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
 
   <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
-  <remove-project path="bionic" name="Halium/android_bionic" />
   <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
   <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
 
@@ -16,8 +15,7 @@
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
-  <project path="bionic" name="android_bionic" revision="halium-7.1" remote="beidl" />
-  
+
   <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
   <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
   <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -3,19 +3,26 @@
     <remote name="beidl" fetch="git://github.com/beidl" />
     <remote name="sony" fetch="git://github.com/sonyxperiadev" />
     <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
+    <remote name="ubp" fetch="git://github.com/ubports" />
+    <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
 
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="system/sepolicy" name="android_system_sepolicy" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
+    <remove-project path="halium/libhybris" name="Halium/libhybris" />
+    <remove-project path="halium/audioflingerglue" name="Halium/audioflingerglue" />
     
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
     <project path="system/sepolicy" name="android_system_sepolicy" remote="beidl" revision="halium-7.1" />
     
+    <project path="halium/libhybris" name="libhybris" remote="ubp" revision="refs/heads/hybris-compat-layer-fixes" />
+    <project path="halium/audioflingerglue" name="audioflingerglue" remote="mer-hybris" revision="master" />
+
     <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
-    
+
     <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
@@ -39,4 +46,6 @@
     <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
     <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="android-7.1.1_r55" />
     <project path="vendor/oss/json-c" name="json-c" groups="device" remote="sony" revision="master" />
+
+    <project path="halium/platform-api" name="platform-api" remote="ubp" revision="xenial" />
 </manifest>

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -5,7 +5,6 @@
   <remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
 
   <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
-  <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
   <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
 
   <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
@@ -21,7 +20,6 @@
   <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />
   <project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="master" />
   <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="master" />
-  <project path="vendor/qcom/opensource/dataservices" name="vendor-qcom-opensource-dataservices" groups="device" remote="sony" revision="master" />
   <project path="vendor/qcom/opensource/fm" name="vendor-qcom-opensource-fm" groups="device" remote="sony" revision="master" />
   <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="n-mr1" />
   <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="master" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -1,33 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="beidl" fetch="https://github.com/beidl" />
-  <remote name="sony" fetch="https://github.com/sonyxperiadev" />
-  <remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
+    <remote name="beidl" fetch="git://github.com/beidl" />
+    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
+    <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
+    <remote name="jbb" fetch="https://gitlab.com/JBBgameich/" />
 
-  <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
-  <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
+    <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
+    <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
 
-  <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
-  <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
-  <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
-  <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
-  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
-  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
-  <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+    <project path="halium/halium-install" name="halium-install" revision="master" remote="jbb" />
 
-  <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
-  <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
-  <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />
-  <project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="master" />
-  <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="master" />
-  <project path="vendor/qcom/opensource/fm" name="vendor-qcom-opensource-fm" groups="device" remote="sony" revision="master" />
-  <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="n-mr1" />
-  <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="master" />
-  <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
-  <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="android-7.1.1_r55" />
-  <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
-  <project path="vendor/oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
-  <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
-  <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="android-7.1.1_r55" />
-  <project path="vendor/oss/json-c" name="json-c" groups="device" remote="sony" revision="master" />
+    <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
+    <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
+    <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
+    <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
+    <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />
+  
+    <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+    <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+    <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
+
+    <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
+    <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="nxp" revision="master" />
+    <project path="vendor/broadcom/bt-fm" name="vendor-broadcom-bt-fm" groups="device" remote="sony" revision="master" />
+    <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" groups="device" remote="sony" revision="master" />
+    <project path="vendor/qcom/opensource/fm" name="vendor-qcom-opensource-fm" groups="device" remote="sony" revision="master" />
+    <project path="vendor/qcom/opensource/location" name="vendor-qcom-opensource-location" groups="device" remote="sony" revision="n-mr1" />
+    <project path="vendor/qcom/opensource/time-services" name="vendor-qcom-opensource-time-services" groups="device" remote="sony" revision="master" />
+    <project path="vendor/qcom/opensource/wlan" name="hardware-qcom-wlan" groups="device" remote="sony" revision="master" />
+    <project path="vendor/oss/fingerprint"  name="vendor-sony-oss-fingerprint" groups="device" remote="sony" revision="android-7.1.1_r55" />
+    <project path="vendor/oss/macaddrsetup" name="macaddrsetup" groups="device" remote="sony" revision="master" />
+    <project path="vendor/oss/thermanager" name="thermanager" groups="device" remote="sony" revision="master" />
+    <project path="vendor/oss/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
+    <project path="vendor/oss/transpower" name="transpower" groups="device" remote="sony" revision="android-7.1.1_r55" />
+    <project path="vendor/oss/json-c" name="json-c" groups="device" remote="sony" revision="master" />
 </manifest>

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="beidl" fetch="https://github.com/beidl" />
+  <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+  <remote name="NXP" fetch="https://github.com/NXPNFCProject/" />
+
+  <!-- remove-project path="system/sepolicy" name="android_system_sepolicy" / -->
+  <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
+
+  <!-- project path="device/sample" name="device/sample" revision="nougat-mr1-release" remote="aosp" / -->
+  <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1" remote="beidl" />
+  <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1" remote="beidl" />
+  <project path="device/sony/common" name="device-sony-common" revision="n-mr1" remote="beidl" />
+  <!-- project path="device/sony/sepolicy" name="device-sony-sepolicy" revision="n-mr1" remote="beidl" / -->
+  <project path="kernel/sony/suzu" name="device-kernel-suzu" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
+  <project path="vendor/broadcom/wlan" name="vendor-broadcom-wlan" revision="master" remote="sony" />
+  <project path="vendor/sony" name="proprietary_vendor_sony" revision="cm-14.1" remote="them" />
+  <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
+  <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="NXP" revision="master" />
+  <project path="hardware/qcom/display/sde" name="hardware-qcom-display" groups="device" remote="sony" revision="aosp/LA.UM.6.3.r1" />
+
+</manifest>

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -3,19 +3,18 @@
     <remote name="beidl" fetch="git://github.com/beidl" />
     <remote name="sony" fetch="git://github.com/sonyxperiadev" />
     <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="jbb" fetch="https://gitlab.com/JBBgameich/" />
 
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
-
-    <project path="halium/halium-install" name="halium-install" revision="master" remote="jbb" />
-
+    <remove-project path="system/sepolicy" name="android_system_sepolicy" />
+    
+    <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
+    <project path="system/sepolicy" name="android_system_sepolicy" remote="beidl" revision="halium-7.1" />
+    
     <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
-    <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
-    <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="cm-14.1" />
-  
+    
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -9,7 +9,7 @@
   <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
   <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
 
-  <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1" remote="beidl" />
+  <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
   <project path="kernel/sony/suzu" name="device-kernel-suzu" revision="ubports/LA.UM.6.4.r1" remote="beidl" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -11,7 +11,7 @@
   <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
   <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
-  <project path="kernel/sony/suzu" name="device-kerne-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
+  <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
   <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />


### PR DESCRIPTION
This PR also adds new repositories and replaces existing ones for improved hardware support.

Added repos:
* libnfc repositories
* ubports/platform-api

Replaced repo branches:
* libhybris from UBPorts with improved Android 7.1 compatibility
* audioflingerglue from Mer-Hybris
* Sony's fork of Qualcomm's dataservices repo for proper location support