### PR TITLE
Add Dell Venue 7840 (Blackburn, bb)

### DIFF
--- a/manifests/dell_bb.xml
+++ b/manifests/dell_bb.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github"
+            fetch="http://github.com"
+            revision="master" />
+
+    <project path="device/dell/bb" name="fcipaq/android_device_dell_bb" remote="github" />
+    <project path="device/dell/mofd-common" name="fcipaq/android_device_dell_mofd-common" remote="github" />
+
+    <project path="kernel/dell/bb" name="fcipaq/android_kernel_dell_bb" remote="github"/>
+
+<!--
+    vendor blobs repo missing due to legal concerns
+-->
+
+<!--
+    <project path="vendor/dell/bb" name="fcipaq/proprietary_vendor_dell/bb" remote="fcipaq" />
+    <project path="vendor/dell/mofd-common" name="fcipaq/proprietary_vendor_dell/mofd-common" remote="fcipaq" />
+-->
+
+</manifest>
+
+


### PR DESCRIPTION
This is my local manifest to add the Dell Venue 7840 (Blackburn, bb). This also works for the Dell Venue 7040 (Eaglespeak, ep) which feature basically the same hardware.
The repos are forked from the Asus Z00A (a smartphone). (Which also features almost the same hardware).
However, I cannot provide vendor files due to legal concerns.
For now, you need to manually install those files: grab the vendor blobs from Asus Z00A instead e.g. from Github "The Muppets" and change any occurence of "Z00A" to "bb" (also path names).
