### PR TITLE
Added possibility A is capitalized in removeUnneededFolders

### DIFF
--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function removeUnneededFolders {
-    rm -rf [Cc][Mm]actions
+    rm -rf [Cc][Mm][Aa]ctions
     rm -rf [Ll]inage[Aa]ctions
     rm -rf [Dd]oze
     rm -rf [Kk]ey[Hh]andler


### PR DESCRIPTION
The folder CMActions, when present, is not deleted by the function removedUnneededFolders since the A is capitalized, causing errors in later steps of the build process.