### PR TITLE
FP2: use vendor repo from "them"

### DIFF
--- a/manifests/fairphone_FP2.xml
+++ b/manifests/fairphone_FP2.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <project path="device/fairphone/FP2" name="Halium/android_device_fairphone_fp2" remote="hal" />
-
     <project path="kernel/fairphone/msm8974" name="Halium/android_kernel_fairphone_msm8974" remote="hal" />
-
-    <project path="vendor/fairphone/FP2" name="FairBlobs/proprietary_vendor_fairphone" remote="hal" />
+    <project path="vendor/fairphone" name="proprietary_vendor_fairphone" remote="them" />
 </manifest>


### PR DESCRIPTION
The repo from FairBlobs are outdated and isn't in sync with new
LineageOS branch.

Change-Id: I994d6ae1a0da6b91feaae370998eaa77c75e01ee