### PR TITLE
suzu: Use modified AOSP Audio HAL

### DIFF
--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -7,7 +7,7 @@
     <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
 
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
-    <remove-project path="hardware/qcom/audio-caf/msm8998" name="android_hardware_qcom_audio" />
+    <remove-project path="hardware/qcom/audio" name="android_hardware_qcom_audio" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
@@ -19,7 +19,7 @@
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
 
-    <project path="hardware/qcom/audio-caf/msm8998" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8998" remote="beidl" />
+    <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
     <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
 


### PR DESCRIPTION
This patched version is required to get call audio working.

Long term plan is to merge required commits into Haliums Non-CAF Audio HAL.