### PR TITLE
suzu: Use patched media HAL, libhybris & recovery

### DIFF
--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -6,19 +6,22 @@
     <remote name="ubp" fetch="git://github.com/ubports" />
     <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
 
+    <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
+    <remove-project path="halium/libhybris" name="Halium/libhybris" />
     <remove-project path="hardware/qcom/audio" name="android_hardware_qcom_audio" />
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="hardware/qcom/media" name="android_hardware_qcom_media" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
-    <remove-project path="halium/libhybris" name="Halium/libhybris" />
 
-    <project path="halium/libhybris" name="libhybris" remote="ubp" revision="refs/heads/hybris-compat-layer-fixes" />
+    <project path="bootable/recovery" name="android_bootable_recovery" remote="beidl" revision="ubp-7.1" />
 
     <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
+
+    <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="halium-7.1-camfixes" />
 
     <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
     <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -8,8 +8,9 @@
 
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
     <remove-project path="hardware/qcom/audio" name="android_hardware_qcom_audio" />
-    <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
+    <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
+    <remove-project path="hardware/qcom/media" name="android_hardware_qcom_media" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
     <remove-project path="halium/libhybris" name="Halium/libhybris" />
 
@@ -22,6 +23,7 @@
     <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
     <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
+    <project path="hardware/qcom/media" name="android_hardware_qcom_media" remote="beidl" revision="halium-7.1" />
 
     <project path="kernel/sony/suzu" name="device-kernel-loire" revision="ubports/LA.UM.6.4.r1" remote="beidl" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/fw-api" name="vendor-qcom-opensource-wlan-fw-api" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />


### PR DESCRIPTION
This replaces the default AOSP-provided media HAL with a custom HAL with compile fixes,
uses libhybris with camera fixes (until it's merged) and provides a system-image-upgrader compatible recovery.