### PR TITLE
suzu: libhybris, add gpg and updated toybox, use rooted adb

### DIFF
--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -12,6 +12,7 @@
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
     <remove-project path="hardware/qcom/media" name="android_hardware_qcom_media" />
+    <remove-project path="system/core" name="Halium/android_system_core" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
 
     <project path="bootable/recovery" name="android_bootable_recovery" remote="beidl" revision="ubp-7.1" />
@@ -21,6 +22,8 @@
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
 
     <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
+    <project path="external/libnfc-nci" name="platform/external/libnfc-nci" groups="pdk" remote="aosp" />
+    <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" groups="pdk" remote="aosp" />
     <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
 
     <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
@@ -33,8 +36,7 @@
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qca-wifi-host-cmn" name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
     <project path="kernel/sony/suzu/drivers/staging/wlan-qc/qcacld-3.0" name="vendor-qcom-opensource-wlan-qcacld-3.0" groups="device" remote="sony" revision="aosp/LA.UM.6.4.r1" />
 
-    <project path="external/libnfc-nci" name="platform/external/libnfc-nci" groups="pdk" remote="aosp" />
-    <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" groups="pdk" remote="aosp" />
+    <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
 
     <project path="vendor/nxp/" name="vendor-nxp" groups="device" remote="sony" revision="master" />
     <project path="vendor/nxp/NXPNFCC_FW" name="NXPNFCC_FW" groups="device" remote="nxp" revision="master" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -3,13 +3,11 @@
     <remote name="beidl" fetch="git://github.com/fredldotme" />
     <remote name="sony" fetch="git://github.com/sonyxperiadev" />
     <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="ubp" fetch="git://github.com/ubports" />
     <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
     <remove-project path="external/toybox" name="android_external_toybox" />
-    <remove-project path="halium/libhybris" name="Halium/libhybris" />
     <remove-project path="hardware/qcom/audio" name="android_hardware_qcom_audio" />
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
     <remove-project path="hardware/qcom/display" name="android_hardware_qcom_display" />
@@ -24,8 +22,6 @@
 
     <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
     <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
-
-    <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="halium-7.1-camfixes" />
 
     <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
     <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -8,6 +8,7 @@
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />
+    <remove-project path="external/toybox" name="android_external_toybox" />
     <remove-project path="halium/libhybris" name="Halium/libhybris" />
     <remove-project path="hardware/qcom/audio" name="android_hardware_qcom_audio" />
     <remove-project path="hardware/qcom/camera" name="android_hardware_qcom_camera" />
@@ -20,6 +21,9 @@
     <project path="device/sony/suzu" name="device-sony-suzu" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/loire" name="device-sony-loire" revision="n-mr1-ubports" remote="beidl" />
     <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
+
+    <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
+    <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
 
     <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="halium-7.1-camfixes" />
 


### PR DESCRIPTION
gpg and updated toybox (for fixed 'tar' command) are required by the UBports system-image-upgrader.
Rooted adbd is used to match behaviour of TWRP and fulfill ubuntu-device-flash requirements.