### PR TITLE
onyx: use more up-to-date repos

### DIFF
--- a/manifests/oneplus_onyx.xml
+++ b/manifests/oneplus_onyx.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project path="device/oneplus/onyx" name="corpuscle/android_device_oneplus_onyx" remote="hal" revision="cm-14.1" />
+    <project path="device/oneplus/onyx" name="ittat/device_oneplus_onyx" remote="hal" revision="ut-7.1" />
 
-    <project path="device/oppo/common" name="android_device_oppo_common" remote="los" />
+    <project path="device/oppo/common" name="android_device_oppo_common" remote="los" revision="cm-14.1" />
 
-    <project path="kernel/oneplus/onyx" name="android_kernel_oneplus_onyx" remote="los" />
+    <project path="kernel/oneplus/onyx" name="ittat/kernel_oneplus_onyx" remote="hal" revision="ut-7.1" />
 
-    <project path="vendor/oneplus" name="proprietary_vendor_oneplus" remote="them" />
+    <project path="vendor/oneplus" name="proprietary_vendor_oneplus" remote="them" revision="cm-14.1" />
 </manifest>


### PR DESCRIPTION
Build  and boot to uports7.1

Tree: halium-7.1

- [x] Create manifest : https://github.com/Halium/halium-devices/pull/202
- [x] Boot image and system image build successfully
- [x] Device boots into rootfs, `usb: Manufacturer: GNU/Linux Device` appears in `dmesg` on host.
- [x] LXC container starts and does not crash
- [ ] libhybris tests
  * [x] test_gps
  * [ ] test_hwcomposer
  * [x] test_lights
  * [x] test_vibrator
  * [x] test_wifi
  * [ ] test_sensors
  * [ ] test_audio
  * [ ] test_camera
  * [ ] test_input
  * [ ] test_recorder

- [x] UBports rootfs 
  * [x] gps
  * [x] hwcomposer
  * [x] lights
  * [x] vibrator
  * [x] wifi
  * [x] audio
  * [x] anbox
  * [ ] camera