### PR TITLE
reuse fredldotme repositories for dore/tone

### DIFF
--- a/manifests/sony_dora.xml
+++ b/manifests/sony_dora.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="sjllls" fetch="git://github.com/sjllls" />
+    <remote name="beidl" fetch="git://github.com/fredldotme" />
     <remote name="sony" fetch="git://github.com/sonyxperiadev" />
     <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
     <remote name="ubp" fetch="git://github.com/ubports" />
@@ -15,25 +16,25 @@
     <remove-project path="system/core" name="Halium/android_system_core" />
     <remove-project path="vendor/qcom/opensource/dataservices" name="android_vendor_qcom_opensource_dataservices" />
 
-    <project path="bootable/recovery" name="android_bootable_recovery" remote="sjllls" revision="ubp-7.1" />
+    <project path="bootable/recovery" name="android_bootable_recovery" remote="beidl" revision="ubp-7.1" />
 
     <project path="device/sony/dora" name="device-sony-dora" revision="n-mr1-ubports" remote="sjllls" />
     <project path="device/sony/tone" name="device-sony-tone" revision="n-mr1-ubports" remote="sjllls" />
-    <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="sjllls" />
-    <project path="device/sony/common-init" name="device-sony-common-init" revision="n-mr1-ubports" remote="sjllls" />
+    <project path="device/sony/common" name="device-sony-common" revision="n-mr1-ubports" remote="beidl" />
+    <project path="device/sony/common-init" name="device-sony-common-init" revision="n-mr1-ubports" remote="beidl" />
 
     <project path="external/elfutils" name="platform/external/elfutils" groups="pdk" remote="aosp" />
-    <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="sjllls" />
+    <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
     <project path="external/libnfc-nci" name="platform/external/libnfc-nci" groups="pdk" remote="aosp" />
     <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" groups="pdk" remote="aosp" />
-    <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="sjllls" />
+    <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
 
-    <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="sjllls" />
+    <project path="hardware/qcom/audio" name="android_hardware_qcom_audio_aosp" groups="qcom,qcom_audio" revision="halium-7.1" remote="beidl" />
     <project path="hardware/qcom/camera" name="camera" groups="device" remote="sony" revision="aosp/LA.UM.5.7.r1" />
-    <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="sjllls" revision="halium-7.1" />
-    <project path="hardware/qcom/media" name="android_hardware_qcom_media" remote="sjllls" revision="halium-7.1" />
+    <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
+    <project path="hardware/qcom/media" name="android_hardware_qcom_media" remote="beidl" revision="halium-7.1" />
 
-    <project path="kernel/sony/dora" name="kernel" revision="ubports/LA.UM.5.7.r1" remote="sjllls" />
+    <project path="kernel/sony/dora" name="kernel" revision="ubports/LA.UM.5.7.r1" remote="beidl" />
 
     <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
 


### PR DESCRIPTION
Most repositories do not need to be adapted, additionally all ftbfs issues in the kernel repository were recently resolved.