### PR TITLE
use common loire kernel repo

### DIFF
--- a/manifests/sony_kugo.xml
+++ b/manifests/sony_kugo.xml
@@ -34,7 +34,7 @@
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
     <project path="hardware/qcom/media" name="android_hardware_qcom_media" remote="beidl" revision="halium-7.1" />
 
-    <project path="kernel/sony/kugo" name="device-kernel-loire" revision="ubports/LA.UM.5.7.r1" remote="kelmes" />
+    <project path="kernel/sony/kugo" name="device-kernel-loire" revision="ubports/LA.UM.5.7.r1" remote="beidl" />
 
     <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
 


### PR DESCRIPTION
The kugo defonfig is now included in @fredldotme's loire kernel repo. We can now use the same repo for both suzu and kugo kernels.