### PR TITLE
fix reponame for dora

### DIFF
--- a/manifests/sony_dora.xml
+++ b/manifests/sony_dora.xml
@@ -34,7 +34,7 @@
     <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="beidl" revision="halium-7.1" />
     <project path="hardware/qcom/media" name="android_hardware_qcom_media" remote="beidl" revision="halium-7.1" />
 
-    <project path="kernel/sony/dora" name="kernel" revision="ubports/LA.UM.5.7.r1" remote="beidl" />
+    <project path="kernel/sony/dora" name="device-kernel-loire" revision="ubports/LA.UM.5.7.r1" remote="beidl" />
 
     <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
 


### PR DESCRIPTION
I forgot to set the name back to fredls kernel repository name when moving from sjllls.