### PR TITLE
manifests: Xiaomi Beryllium, Land and Mido: Update vendor repo

### DIFF
--- a/manifests/xiaomi_beryllium.xml
+++ b/manifests/xiaomi_beryllium.xml
@@ -2,5 +2,5 @@
 <manifest>
     <project path="device/xiaomi/beryllium" name="android_device_xiaomi_beryllium" remote="aosp" />
     <project path="device/xiaomi/sdm845-common" name="android_device_xiaomi_sdm845-common" remote="hal" />
-    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them" />
+    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them2" />
 </manifest>

--- a/manifests/xiaomi_land.xml
+++ b/manifests/xiaomi_land.xml
@@ -8,5 +8,5 @@
     
     <project path="kernel/xiaomi/msm8937" name="android_kernel_xiaomi_msm8937" remote="dvs_repo" />
     
-    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them" />
+    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them2" />
 </manifest>

--- a/manifests/xiaomi_mido.xml
+++ b/manifests/xiaomi_mido.xml
@@ -4,5 +4,5 @@
 
     <project path="kernel/xiaomi/msm8953" name="herrie82/android_kernel_xiaomi_msm8953" remote="hal" revision="pgz-14.1-eb8" />
 
-    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them" />
+    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them2" />
 </manifest>


### PR DESCRIPTION
To GitLab to solve issue with Xiaomi vendor that was removed from GitHub.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>