### PR TITLE
Update huawei_angler (adapted to Ubuntu Touch)

### DIFF
--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="angler-halium" 
-            fetch="https://github.com/angler-halium/"
-            revision="halium-7.1" />
 
-    <project path="device/huawei/angler" name="device_huawei_angler" remote="angler-halium" />
-    
-    <project path="kernel/huawei/angler" name="kernel_huawei_angler" remote="angler-halium" />
-    
     <project path="vendor/huawei" name="proprietary_vendor_huawei" remote="them" />
+
+    <remote name="Flohack74" fetch="https://github.com/Flohack74/" revision="halium-7.1" />
+    <project path="device/huawei/angler" name="android_device_huawei_angler" remote="Flohack74" />
+    <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="Flohack74" />
+
+    <remote name="beidl" fetch="git://github.com/fredldotme" />
+    <remote name="rargente" fetch="git://github.com/Rargente" />
+    <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
+    <remove-project path="external/toybox" name="android_external_toybox" />
+    <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
+    <remove-project path="bootable/recovery" name="android_bootable_recovery" />
+    <project path="bootable/recovery" name="android_bootable_recovery" remote="rargente" revision="ubp-7.1" />
+
+    <remove-project path="system/core" name="Halium/android_system_core" />
+    <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
+
+
 </manifest>


### PR DESCRIPTION
I am not sure how we gonna deal with this situation:
- Originally Halium was meant to be a common base for all our OSes
- Now at least until next year, Ubuntu Touch will not be able to have the same kernel configs as "real" Halium devices (and I doubt that especially with Bluetooth and apparmor this will ever be the case)
- systemd is not even close for us (but will be considered for 20.04 upgrade)
- Our current CI pipeline is made so it will try to fetch the manifest from here
Thats quite contradicting. I dont want a fight between maintainers of ports since they have only 1 source of truth for the manifest.
@bhush9 @mariogrip what are we doing about this?
Nevertheless I am pushing my "Ubuntu Touch" manifest here, since otherwise I am blocked with releasing it via our CI (which i scurrently the only way to get it installed for users with the installer and to follow OTAs)
- Proposal: Store "real" Ubunt Touch manifests somewhere else OR
- allow system-image to pull the files from other sources (maintainer-hosted) OR
- allow people to have their own system-image server
Anyways it cannot go on with this: UBports cannot host the build pipeline for all ported devices without impacting our daily work. We need our CI for the core stuff, not for building 20 phone images daily (and blocking other builds)
