### PR TITLE
Let FP2 use ubports recovery image

### DIFF
--- a/manifests/fairphone_FP2.xml
+++ b/manifests/fairphone_FP2.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project path="device/fairphone/FP2" name="Halium/android_device_fairphone_fp2" remote="hal" />
+    <project path="device/fairphone/FP2" name="Halium/android_device_fairphone_fp2" remote="hal" revision="halium-7.1_ubuntu"/>
     <project path="kernel/fairphone/msm8974" name="Halium/android_kernel_fairphone_msm8974" remote="hal" />
     <project path="vendor/fairphone" name="proprietary_vendor_fairphone" remote="them" />
+
+    <remote name="beidl" fetch="git://github.com/fredldotme" />
+
+    <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
+    <remove-project path="external/toybox" name="android_external_toybox" />
+    <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />
+
+    <remove-project path="bootable/recovery" name="android_bootable_recovery" />
+    <project path="bootable/recovery" name="ubports/android_bootable_recovery" remote="hal" revision="halium-7.1" />
+
+    <remove-project path="system/core" name="Halium/android_system_core" />
+    <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" revision="halium-7.1-adbroot" />
 </manifest>


### PR DESCRIPTION
This MR adjusts the FP2 manifest to use the ubports recovery image.