### PR TITLE
Fix Google Pixel setup

### DIFF
--- a/setup
+++ b/setup
@@ -78,6 +78,23 @@ else
         )
     fi
 
+    # Some device trees are lazy and contain more than one device. Check subdirectory with devicename, too
+    # (e.g. Google Pixel)
+    if [ -f $DEVICE_TREE/$DEVICE/setup-makefiles.sh ]; then
+        echo "I: Refreshing device vendor repository: device/$VENDOR/$DEVICE"
+        (
+            cd $DEVICE_TREE/$DEVICE
+            for i in $(find . -name "*proprietary-*.txt"); do
+                echo "I: Processing proprietary blob file: device/$VENDOR/$DEVICE/$i"
+                grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i >$i".tmp" && mv $i".tmp" $i
+            done
+            # Set executable bit, needed for some device trees
+            chmod +x ./setup-makefiles.sh
+            # Actually run the script
+            ./setup-makefiles.sh
+        )
+    fi
+
     # Since we don't use SELinux we want to make sure we remove the
     # ",context=u....:s0" from the fstab file(s) in the $DEVICE folder so we can
     # mount the partitions without issues

--- a/setup
+++ b/setup
@@ -60,6 +60,12 @@ else
     fi
 
     DEVICE_TREE=$REPO_ROOT/device/$VENDOR/$DEVICE
+
+    # Hack: Google Pixel has lazy device tree structure, 2 devices in one
+    if [[ ( $VENDOR="google" ) && ( $DEVICE="sailfish" ) ]]; then
+        DEVICE_TREE=$REPO_ROOT/device/$VENDOR/marlin
+    fi
+
     VENDOR_TREE=$REPO_ROOT/vendor/$VENDOR
 
     echo "*******************************************"


### PR DESCRIPTION
Google Pixel device tree contains both devices in LOS sources. Needs hacks to not break setup script:

- Device tree has subdirectories for each device, that need to be scanned for additional pruning
- Also, setup script needs to be aware that when sailfish is selected, use marlin directory name instead

