### PR TITLE
Add Google Pixel and Pixel XL in one manifest

### DIFF
--- a/manifests/google_sailfish_marlin.xml
+++ b/manifests/google_sailfish_marlin.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+<project path="vendor/google" name="TheMuppets/proprietary_vendor_google" />
+
+<remote name="Flohack74" fetch="https://github.com/Flohack74/" revision="halium-9.0" />
+
+<project path="device/google/marlin" name="android_device_google_marlin" remote="Flohack74" />
+<project path="kernel/google/marlin" name="android_kernel_google_marlin" remote="Flohack74" />
+
+<project path="external/puffin" name="LineageOS/android_external_puffin" />
+
+<project path="device/google/contexthub" name="device/google/contexthub" groups="device,marlin,pdk" remote="aosp" />
+<project path="external/tinyxml" name="platform/external/tinyxml" groups="pdk" remote="aosp" />
+
+</manifest>
+


### PR DESCRIPTION
Since LineageOS decided to put both devices into the same device repo, we follow that idea and so this manifest can build both devices. See also #281 

Change-Id: I91f781f461a46e5d272fcb8f3bf8c5433d54f17f