### PR TITLE
Add hack for Google Pixel 2/2XL

### DIFF
--- a/setup
+++ b/setup
@@ -71,6 +71,12 @@ else
 
     DEVICE_TREE=$REPO_ROOT/device/$VENDOR/$DEVICE
 
+    # Hack: Google Pixel 2 was wrongly announced as muskie, and then changed to walleye codename
+    # we need to check muskie repo here instead of walleye since LineageOS did a crazy hack too
+    if [[ ( $VENDOR = "google" ) && ( $DEVICE = "walleye" ) ]]; then
+        DEVICE_TREE=$REPO_ROOT/device/$VENDOR/muskie
+    fi
+
     # Hack: Google Pixel has lazy device tree structure, 2 devices in one
     if [[ ( $VENDOR = "google" ) && ( $DEVICE = "sailfish" ) ]]; then
         DEVICE_TREE=$REPO_ROOT/device/$VENDOR/marlin
@@ -80,11 +86,11 @@ else
 
     echo "*******************************************"
     if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
-        echo "I: Refreshing device vendor repository: device/$VENDOR/$DEVICE"
+        echo "I: Refreshing device vendor repository: device/$VENDOR/$(basename $DEVICE_TREE)"
         (
             cd $DEVICE_TREE
             for i in $(find . -name "*proprietary-*.txt"); do
-                echo "I: Processing proprietary blob file: device/$VENDOR/$DEVICE/$i"
+                echo "I: Processing proprietary blob file: device/$VENDOR/$(basename $DEVICE_TREE)/$i"
                 grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $i >$i".tmp" && mv $i".tmp" $i
             done
             # Set executable bit, needed for some device trees
@@ -115,14 +121,14 @@ else
     # ",context=u....:s0" from the fstab file(s) in the $DEVICE folder so we can
     # mount the partitions without issues
     cd $DEVICE_TREE && for j in $(find . -name "fstab.*"); do
-        echo "I: Processing fstab file: device/$VENDOR/$DEVICE/$j"
+        echo "I: Processing fstab file: device/$VENDOR/$(basename $DEVICE_TREE)/$j"
         sed -r 's/(,context=.*:s0)//' $j >$j".tmp" && mv $j".tmp" $j
     done
 
     # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
     # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
     cd $DEVICE_TREE
-    echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$DEVICE"
+    echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$(basename $DEVICE_TREE)"
     removeUnneededFolders
 
     # Loop through values in $DEVICE_COMMON_TEMP


### PR DESCRIPTION
Thats another weird case: Google Pixel 2 was originally announced as being codename muskie, so LineageOS seems to have tried to follow that name, and already set up everything, when Google decided that the codename will be changed to walleye.

So now for devicename walleye we have to change the device tree name again back to muskie, since that is hardcoded all over the place. In a follow-up commit I will present a manifest that can be used together with that change.

Device setup script does many assumptions about directory names based on device name. We should eventually do it similar as LOS, to actually find the files in the subdirs, parse them and learn about which device is located where.

The changes to echo lines is following on the changes also for Pixel: We should print the effective directory used there, not just blindly use the device name. The actual code was already working well.
