### PR TITLE
Add manifest for Google Pixel 2/2XL

### DIFF
--- a/manifests/google_walleye_taimen.xml
+++ b/manifests/google_walleye_taimen.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+<project path="vendor/google" name="TheMuppets/proprietary_vendor_google" />
+
+<remote name="Flohack74" fetch="https://github.com/Flohack74/" revision="halium-9.0" />
+
+<project path="device/google/taimen" name="android_device_google_taimen" remote="Flohack74" />
+<project path="device/google/muskie" name="android_device_google_muskie" remote="Flohack74" />
+<project path="device/google/wahoo" name="android_device_google_wahoo"  remote="Flohack74" />
+<project path="kernel/google/wahoo" name="android_kernel_google_wahoo" remote="Flohack74" />
+
+<project path="external/puffin" name="LineageOS/android_external_puffin" />
+
+</manifest>
+


### PR DESCRIPTION
Note that despite the name containing walleye, the device repo for Pixel 2 is called muskie. Thats intentional and was messed up by Google themselves. See also #284 

Change-Id: I5e3835f4f55030f417d3ab8f13b837f3bd667a20