### PR TITLE
Add Xiaomi Tissot (A1) manifest

### DIFF
--- a/manifests/xiaomi_tissot.xml
+++ b/manifests/xiaomi_tissot.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest> 
+    <remote name="them2"
+            fetch="https://gitlab.com/the-muppets"
+            revision="refs/heads/lineage-16.0" />
+    
+    <project path="device/xiaomi/tissot" name="herrie82/android_device_xiaomi_tissot-1" revision="halium-9.0" />
+    <project path="device/xiaomi/msm8953-common" name="herrie82/android_device_xiaomi_msm8953-common" revision="halium-9.0-extended" />
+
+    <project path="kernel/xiaomi/msm8953" name="Tofee/tissot" revision="tissot/4.9/halium-9.0"/>
+
+    <project path="vendor/xiaomi" name="proprietary_vendor_xiaomi" remote="them2" />
+</manifest>


### PR DESCRIPTION
For the setup script, the idea is that we often have missing entries in the proprietary-files.txt files.
I don't see any use-case where we wouldn't want to include some of the files in the proprietary vendor repos, so in the setup script I try to add missing files in proprietary-files.txt.