### PR TITLE
Add a step to complete proprietary-files.txt from vendor repo

### DIFF
--- a/extract_proprietary_files_from_vendor_repo.sh
+++ b/extract_proprietary_files_from_vendor_repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Lists the content of the vendor proprietary files as relative path
+# Output is done on standard output
+
+VENDOR_TREE=$1
+DEST_FILE=$2
+
+if [ -z $VENDOR_TREE ]; then
+    echo "Please specify a vendor directory containing proprietary files, like vendor/<vendor>/<device>"
+    exit 0
+fi
+
+if [ -d $VENDOR_TREE/proprietary ]; then
+    (
+        # get the list of relative paths
+        cd $VENDOR_TREE/proprietary
+        find . -type f | sed 's@^\./@@'
+    )
+fi
+

--- a/setup
+++ b/setup
@@ -80,6 +80,25 @@ else
 
     echo "*******************************************"
     if [ -f $DEVICE_TREE/setup-makefiles.sh ]; then
+        if [ -f $DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh -a -d "$VENDOR_TREE/$DEVICE/proprietary" ]; then
+            echo "I: Completing device vendor proprietary blob file"
+            (
+                # generate the whole list from the vendor repo
+                cd $DEVICE_TREE
+
+                chmod +x $DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh
+                
+                OUTPUT_PROPRIETARY_FILE=$(find $DEVICE_TREE -name "*proprietary-*.txt" -print -quit)
+                echo "I: Adding missing entries in $OUTPUT_PROPRIETARY_FILE"
+                printf "\n# Complementary files added by Halium's setup\n" >> $OUTPUT_PROPRIETARY_FILE
+                
+                # Add missing entries in proprietary-files.txt : device repo
+                for l in $($DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh $VENDOR_TREE/$DEVICE); do
+                    grep -q $l "$DEVICE_TREE"/*proprietary-*.txt || echo $l >> $OUTPUT_PROPRIETARY_FILE
+                done
+            )
+        fi
+
         echo "I: Refreshing device vendor repository: device/$VENDOR/$DEVICE"
         (
             cd $DEVICE_TREE
@@ -114,7 +133,7 @@ else
     # Since we don't use SELinux we want to make sure we remove the
     # ",context=u....:s0" from the fstab file(s) in the $DEVICE folder so we can
     # mount the partitions without issues
-    cd $DEVICE_TREE && for j in $(find . -name "fstab.*"); do
+    cd $DEVICE_TREE && for j in $(find . -name "fstab*"); do
         echo "I: Processing fstab file: device/$VENDOR/$DEVICE/$j"
         sed -r 's/(,context=.*:s0)//' $j >$j".tmp" && mv $j".tmp" $j
     done
@@ -130,6 +149,25 @@ else
         for k in $DEVICE_COMMON_TEMP; do
             echo "I: Procession device vendor common folder: device/$VENDOR/$k"
             DEVICE_COMMON_TREE=$REPO_ROOT/device/$VENDOR/$k
+
+            if [ -f $DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh -a -d "$VENDOR_TREE/$k/proprietary" ]; then
+                echo "I: Completing device vendor common proprietary blob file"
+                (
+                    # generate the whole list from the vendor repo
+                    cd $DEVICE_COMMON_TREE
+
+                    chmod +x $DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh
+                    
+                    OUTPUT_PROPRIETARY_FILE=$(find $DEVICE_COMMON_TREE -name "*proprietary-*.txt" -print -quit)
+                    echo "I: Adding missing entries in $OUTPUT_PROPRIETARY_FILE"
+                    printf "\n# Complementary files added by Halium's setup\n" >> $OUTPUT_PROPRIETARY_FILE
+                    
+                    # Add missing entries in proprietary-files.txt : device common repo
+                    for l in $($DEVICES_ROOT/extract_proprietary_files_from_vendor_repo.sh $VENDOR_TREE/$k); do
+                        grep -q $l "$DEVICE_COMMON_TREE"/*proprietary-*.txt || echo $l >> $OUTPUT_PROPRIETARY_FILE
+                    done
+                )
+            fi
 
             # We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or
             # $PLATFORM_COMMON available for setup-makefiles.sh in the common
@@ -158,7 +196,7 @@ else
             # Since we don't use SELinux we want to make sure we remove the
             # ",context=u....:s0" from the fstab file(s) in the $DEVICE_COMMON
             # folder so we can mount the partitions without issues
-            cd $DEVICE_COMMON_TREE && for m in $(find . -name "fstab.*"); do
+            cd $DEVICE_COMMON_TREE && for m in $(find . -name "fstab*"); do
                 echo "I: Processing fstab file: device/$VENDOR/$m"
                 sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
             done
@@ -231,7 +269,7 @@ else
             # Since we don't use SELinux we want to make sure we remove the
             # ",context=u....:s0" from the fstab file(s) in the $VENDOR_COMMON
             # folder so we can mount the partitions without issues
-            cd $VENDOR_COMMON_TREE && for m in $(find . -name "fstab.*"); do
+            cd $VENDOR_COMMON_TREE && for m in $(find . -name "fstab*"); do
                 echo "I: Processing fstab file: device/$VENDOR/$k/$m"
                 sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
             done


### PR DESCRIPTION
For the setup script, the idea is that we often have missing entries in the proprietary-files.txt files.
I don't see any use-case where we wouldn't want to include some of the files in the proprietary vendor repos, so in the setup script I try to add missing files in proprietary-files.txt.