### PR TITLE
Move ASUS Z00ED sources to UBports Z00E organization

### DIFF
--- a/manifests/asus_Z00ED.xml
+++ b/manifests/asus_Z00ED.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-	<remote name="adz"
-		fetch="https://github.com/adazem009" />
-	<project path="device/asus/Z00ED" name="android_device_asus_Z00ED" remote="adz" revision="UBports-N" />
-	<project path="device/asus/msm8916-common" name="android_device_asus_msm8916-common" remote="adz" revision="halium" />
-	<project path="device/asus/qcom/common" name="android_device_asus_qcom_common" remote="adz" revision="N" />
-	<project path="vendor/asus" name="proprietary_vendor_asus" remote="adz" revision="halium-7.1" />
-	<project path="kernel/asus/msm8916" name="android_kernel_asus_msm8916" remote="adz" revision="UBports-N" />
+	<!-- ASUS ZenFone 2 Laser ZE500KL -->
+	<remote name="ubpZ00E" fetch="https://github.com/ubports-z00e" revision="UBports-N" />
+	<project name="android_kernel_asus_msm8916" path="kernel/asus/msm8916" remote="ubpZ00E" />
+	<project name="android_device_asus_Z00ED" path="device/asus/Z00ED" remote="ubpZ00E" />
+	<project name="android_device_asus_msm8916-common" path="device/asus/msm8916-common" remote="ubpZ00E" />
+	<project name="android_vendor_asus" path="vendor/asus" remote="ubpZ00E" />
 </manifest>


### PR DESCRIPTION
We've moved the device sources to the UBports Z00E GitHub organization. Old sources were deleted, so this manifest should be updated.