### PR TITLE
halium-devices: Add Halium 9.0 port of LG Mako (Nexus 4)

### DIFF
--- a/manifests/lge_mako.xml
+++ b/manifests/lge_mako.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <project path="device/lge/mako" name="herrie82/android_device_lge_mako" revision="halium-9.0" />
+
+    <project path="kernel/lge/mako" name="herrie82/android_kernel_lge_mako" revision="halium-9.0" />
+
+    <project path="vendor/lge" name="herrie82/proprietary_vendor_lge" revision="halium-9.0" />
+    <!-- Inclusion of GPG that was introduced with https://github.com/Halium/android/commit/8e43a9652d0aecc3a5cb462362aa8a1efd44e647 causes issues on ARMV7 targets,  therefore revert these changes -->
+    <remove-project name="ubports/android_external_gpg" />
+    <remove-project name="ubports/halium_bootable_recovery" />
+    <project path="bootable/recovery" name="LineageOS/android_bootable_recovery" groups="pdk" />
+</manifest>


### PR DESCRIPTION
Initial port of LG Mako (Nexus 4) to Halium 9.0.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>