### PR TITLE
Remove broken remote for xiaomi ysl

### DIFF
--- a/manifests/xiaomi_ysl.xml
+++ b/manifests/xiaomi_ysl.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="device_xiaomi_ysl"
-        fetch="https://github.com/jmsgfhr"
-        revision="lineage-16.0" />
+        fetch="https://github.com/Raezroth"
+        revision="halium9" />
 
-    <project path="device/xiaomi/ysl" name="device_xiaomi_ysl" remote="device_xiaomi_ysl" revision="lineage-16.0" />
+    <project path="device/xiaomi/ysl" name="device_xiaomi_ysl" remote="device_xiaomi_ysl" revision="halium9">
     
-    <project path="vendor/xiaomi/ysl" name="vendor_xiaomi_ysl" remote="device_xiaomi_ysl" revision="lineage-16.0" />
+    <project path="vendor/xiaomi/ysl" name="vendor_xiaomi_ysl" remote="device_xiaomi_ysl" revision="halium9"/>
     
-    <project path="kernel/xiaomi/ysl" name="kernel_xiaomi_msm8953-ysl" remote="device_xiaomi_ysl" revision="lineage-16.0" />
+    <project path="kernel/xiaomi/msm8953" name="kernel_xiaomi_msm8953-ysl" remote="device_xiaomi_ysl" revision="halium9"/>
 
 </manifest>


### PR DESCRIPTION
Files weren't weren't put in right paths and remote for xiaomi ysl (    <remote name="device_xiaomi_ysl" fetch="https://github.com/jmsgfhr revision="lineage-16.0" /> ) seems dead