### PR TITLE
devices: add FM radio repository to xiaomi_violet

### DIFF
--- a/manifests/xiaomi_violet.xml
+++ b/manifests/xiaomi_violet.xml
@@ -19,4 +19,8 @@
   <project path="vendor/xiaomi/violet"
     name="android_vendor_xiaomi_violet"
     remote="ubuntu-touch-xiaomi-violet" />
+
+  <project path="vendor/ubports/fm-bridge"
+    name="fm-bridge"
+    remote="ubuntu-touch-xiaomi-violet" />
 </manifest>


### PR DESCRIPTION
This repository is used when building the vendor image:
https://gitlab.com/ubuntu-touch-xiaomi-violet/android_vendor_xiaomi_violet/-/blob/halium-9.0/violet-vendor.mk#L1302

Change-Id: I49e337d19548ebe1dc5446223a3326cb29898c42