### PR TITLE
Change URL scheme according to Github SecOps changes

### DIFF
--- a/manifests/bq_tenshi.xml
+++ b/manifests/bq_tenshi.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="guf" fetch="git://github.com/stefanomelchior" />
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="ubp" fetch="git://github.com/ubports" />
+    <remote name="guf" fetch="https://github.com/stefanomelchior" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="ubp" fetch="https://github.com/ubports" />
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="external/toybox" name="android_external_toybox" />
     <remove-project path="system/core" name="Halium/android_system_core" />

--- a/manifests/fairphone_FP2.xml
+++ b/manifests/fairphone_FP2.xml
@@ -4,7 +4,7 @@
     <project path="kernel/fairphone/msm8974" name="Halium/android_kernel_fairphone_msm8974" remote="hal" />
     <project path="vendor/fairphone" name="proprietary_vendor_fairphone" remote="them" />
 
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
 
     <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
     <remove-project path="external/toybox" name="android_external_toybox" />

--- a/manifests/htc_m7.xml
+++ b/manifests/htc_m7.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="mun" fetch="https://github.com/WolfLink115" revision="cm-14.1" />
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="rargente" fetch="git://github.com/Rargente" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="rargente" fetch="https://github.com/Rargente" />
     
     <remove-project path="external/toybox" name="android_external_toybox" />
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />

--- a/manifests/huawei_angler.xml
+++ b/manifests/huawei_angler.xml
@@ -7,7 +7,7 @@
     <project path="device/huawei/angler" name="android_device_huawei_angler" remote="Flohack74" />
     <project path="kernel/huawei/angler" name="android_kernel_huawei_angler" remote="Flohack74" />
 
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
     <project path="external/gpg" name="android_external_gpg" revision="halium-7.1" remote="beidl" />
     <remove-project path="external/toybox" name="android_external_toybox" />
     <project path="external/toybox" name="android_external_toybox" revision="halium-7.1" remote="beidl" />

--- a/manifests/lge_h815.xml
+++ b/manifests/lge_h815.xml
@@ -6,7 +6,7 @@
 	    revision="refs/tags/cm-14.1" />
 
 
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
 
     <project path="device/lge/h815" name="android_device_lge_h815" remote="abkro" revision="halium-7.1-ut" />
     <project path="device/lge/g4-common" name="android_device_lge_g4-common" remote="abkro" revision="halium-7.1-ut" />

--- a/manifests/oneplus_bacon.xml
+++ b/manifests/oneplus_bacon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
 
     <project path="vendor/oneplus" name="proprietary_vendor_oneplus" remote="them" />
    

--- a/manifests/sony_dora.xml
+++ b/manifests/sony_dora.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="sjllls" fetch="git://github.com/sjllls" />
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="ubp" fetch="git://github.com/ubports" />
-    <remote name="peat-psuwit" fetch="git://github.com/peat-psuwit" />
+    <remote name="sjllls" fetch="https://github.com/sjllls" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="nxp" fetch="https://github.com/NXPNFCProject/" />
+    <remote name="ubp" fetch="https://github.com/ubports" />
+    <remote name="peat-psuwit" fetch="https://github.com/peat-psuwit" />
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />

--- a/manifests/sony_kagura.xml
+++ b/manifests/sony_kagura.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="kd" fetch="git://github.com/konradybcio" />
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="ubp" fetch="git://github.com/ubports" />
-    <remote name="peat-psuwit" fetch="git://github.com/peat-psuwit" />
+    <remote name="kd" fetch="https://github.com/konradybcio" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="nxp" fetch="https://github.com/NXPNFCProject/" />
+    <remote name="ubp" fetch="https://github.com/ubports" />
+    <remote name="peat-psuwit" fetch="https://github.com/peat-psuwit" />
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />

--- a/manifests/sony_kugo.xml
+++ b/manifests/sony_kugo.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="kelmes" fetch="git://github.com/kelmes" />
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
-    <remote name="peat-psuwit" fetch="git://github.com/peat-psuwit" />
+    <remote name="kelmes" fetch="https://github.com/kelmes" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="nxp" fetch="https://github.com/NXPNFCProject/" />
+    <remote name="mer-hybris" fetch="https://github.com/mer-hybris" />
+    <remote name="peat-psuwit" fetch="https://github.com/peat-psuwit" />
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />

--- a/manifests/sony_scorpion.xml
+++ b/manifests/sony_scorpion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="NXP" fetch="git://github.com/NXPNFCProject" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="NXP" fetch="https://github.com/NXPNFCProject" />
     <remote name="flup" fetch="https://gitlab.com/thefluppets/" />
     <remote name="lnj" fetch="https://gitlab.com/lnj" revision="halium-7.1" />
 

--- a/manifests/sony_scorpion_windy.xml
+++ b/manifests/sony_scorpion_windy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="NXP" fetch="git://github.com/NXPNFCProject" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="NXP" fetch="https://github.com/NXPNFCProject" />
     <remote name="flup" fetch="https://gitlab.com/thefluppets/" />
     <remote name="lnj" fetch="https://gitlab.com/lnj" revision="halium-7.1" />
 

--- a/manifests/sony_suzu.xml
+++ b/manifests/sony_suzu.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote name="beidl" fetch="git://github.com/fredldotme" />
-    <remote name="sony" fetch="git://github.com/sonyxperiadev" />
-    <remote name="nxp" fetch="git://github.com/NXPNFCProject/" />
-    <remote name="mer-hybris" fetch="git://github.com/mer-hybris" />
-    <remote name="peat-psuwit" fetch="git://github.com/peat-psuwit" />
+    <remote name="beidl" fetch="https://github.com/fredldotme" />
+    <remote name="sony" fetch="https://github.com/sonyxperiadev" />
+    <remote name="nxp" fetch="https://github.com/NXPNFCProject/" />
+    <remote name="mer-hybris" fetch="https://github.com/mer-hybris" />
+    <remote name="peat-psuwit" fetch="https://github.com/peat-psuwit" />
 
     <remove-project path="bootable/recovery" name="android_bootable_recovery" />
     <remove-project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" />


### PR DESCRIPTION
This caught us offguard and destroyed H7.1 builds in a very random way. But git:// is no longer usable when unauthenticated. Use https instead