### PR TITLE
Evaluate repo sync return code and stop in case of error

### DIFF
--- a/setup
+++ b/setup
@@ -41,6 +41,13 @@ else
     # Synchronize new new sources
     repo sync -c -j$JOBS -q ${REPO_ARGS[@]}
 
+    # Bail out here if repo sync has an error. Else this can lead to corrupted builds
+    # It is not enough to rely on previous repo sync by the user
+    if [ $? -ne 0 ]; then
+        echo "repo sync failed, check your device manifest. Stopping..."
+        exit 1
+    fi
+    
     # Refresh the device & common repositories so apks and jars are not copied
     # For this to work, all apks and jars need to be removed from
     # device/$VENDOR/$DEVICE/*proprietary-files*.txt and


### PR DESCRIPTION
Recently we had a broken repo version that was choking on certain manifests that used "remove-project" a lot. The error was only visible on the initial sync of the CI script. When those errors were fixed subsequent errors in the setup script (after device manifest has been added" went unnoticed.

We need to check repo´s return code all times to prevent broken builds or regressions even (dropped ril and camera functionality on the Sony Xperia X e.g.)