### PR TITLE
[manifest] [halium-9.0] [lilac] Sony Xperia XZ1 Compact: Create Manifest

### DIFF
--- a/manifests/sony_lilac.xml
+++ b/manifests/sony_lilac.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<!-- This branch works good but it is no longer updated as whatawurst focused on newer LOS versions -->
+	<remote
+		name="whatawurst"
+		fetch="https://github.com/whatawurst"
+		revision="lineage-16.0" />
+        
+	<!-- Kernel, Treble, Common platform, Device, Blobs-->
+	<project path="kernel/sony/msm8998" name="android_kernel_sony_msm8998" remote="whatawurst" />
+	<project path="device/sony/common-treble" name="android_device_sony_common-treble" remote="whatawurst" />
+	<project path="device/sony/yoshino" name="android_device_sony_yoshino" remote="whatawurst" />
+	<project path="device/sony/lilac" name="android_device_sony_lilac" remote="whatawurst" />
+	<project path="vendor/sony/lilac" name="android_vendor_sony_lilac" remote="whatawurst" />
+    
+	<!-- WARNING! Some blobs need to be extracted with dedicated script as publishing them on repo may not be lawful -->
+</manifest>


### PR DESCRIPTION
Hi, 
I created manifest for lilac (Sony Xperia XZ1 Compact)
[Sony website](https://www.sony.com/electronics/support/mobile-phones-tablets-mobile-phones/xperia-xz1-compact)
Specs on [gsmarena](https://www.gsmarena.com/sony_xperia_xz1_compact-8610.php)

It has great [support on XDA](https://forum.xda-developers.com/c/sony-xperia-xz1-compact.6926/). 
It has also recent (as of mid of 2022) version LineageOS 19.

Even so I decided to create port based on LineageOS 16.0 (Android 9) because:
1. It has stock OS based on 8 with official update to 9
2. [Droidian](https://droidian.org/) project (I prefer it over UBports) works the best with Android 9 (for now)

**NOTICE**
There is a little mess with building.
`vendor` tree doesn't contain all blobs. 

They need to be extracted before build from device running this specific version of LOS.
There is a [script](https://github.com/whatawurst/android_device_sony_lilac/blob/lineage-16.0/extract-files.sh) on the repo to do that.

You can download it from XDA
[Thread](https://forum.xda-developers.com/t/rom-lineageos-16-0-unofficial-1-2-2020-02-11.3925675/)
[LineageOS 16.0 build by modpunk](https://androidfilehost.com/?w=files&flid=293492&sort_by=date&sort_dir=DESC)
[Dedicated TWRP by modpunk](https://androidfilehost.com/?w=files&flid=286272&sort_by=date&sort_dir=DESC)

I'm not sure it could be related to legal stuff?