### PR TITLE
Refactor setup script, consider 2nd vendor properly

### DIFF
--- a/setup
+++ b/setup
@@ -8,7 +8,7 @@ removeUnneededFolders () {
 }
 
 stripCommonFolder () {
-    echo "I: Processing vendor common folder: /$1/$2/$3"
+    echo "I: Processing common folder: /$1/$2/$3"
     VENDOR_COMMON_TREE=$REPO_ROOT/$1/$2/$3
 
     # We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or

--- a/setup
+++ b/setup
@@ -1,10 +1,66 @@
 #!/bin/bash
 
-function removeUnneededFolders {
+removeUnneededFolders () {
     rm -rf [Cc][Mm]actions
     rm -rf [Ll]inage[Aa]ctions
     rm -rf [Dd]oze
     rm -rf [Kk]ey[Hh]andler
+}
+
+stripCommonFolder () {
+    echo "I: Processing vendor common folder: /$1/$2/$3"
+    VENDOR_COMMON_TREE=$REPO_ROOT/$1/$2/$3
+
+    # We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or
+    # $PLATFORM_COMMON available for setup-makefiles.sh in the common
+    # repository, therefore export them.
+    export VENDOR
+    export DEVICE
+    DEVICE_COMMON_HOLDER=$DEVICE_COMMON
+    export DEVICE_COMMON=${DEVICE_COMMON:=$3}
+    PLATFORM_COMMON_HOLDER=$PLATFORM_COMMON
+    export PLATFORM_COMMON=${PLATFORM_COMMON:=$DEVICE_COMMON}
+
+    if [ -f $VENDOR_COMMON_TREE/setup-makefiles.sh ]; then
+        (
+            cd $VENDOR_COMMON_TREE
+            for l in $(find . -name "*proprietary-*.txt"); do
+                echo "I: Processing proprietary blob file: $1/$2/$3/$l"
+                grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $l >$l".tmp" && mv $l".tmp" $l
+            done
+            # Set executable bit, needed for some device trees
+            chmod +x ./setup-makefiles.sh
+            # Actually run the script
+            ./setup-makefiles.sh
+        )
+    fi
+
+    # Since we don't use SELinux we want to make sure we remove the
+    # ",context=u....:s0" from the fstab file(s) in the $VENDOR_COMMON
+    # folder so we can mount the partitions without issues
+    cd $VENDOR_COMMON_TREE && for m in $(find . -name "fstab*"); do
+        echo "I: Processing fstab file: $1/$2/$3/$m"
+        sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
+    done
+
+   # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
+   # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
+   cd $VENDOR_COMMON_TREE
+   echo "I: Removing components relying on SettingsLib from: $1/$2/$3"
+   removeUnneededFolders
+
+   # Since we can have multiple common repos we need to make sure to set
+   # back the original values in case they exist. Otherwise unset the value.
+   if [ -n "$DEVICE_COMMON_HOLDER" ]; then
+       DEVICE_COMMON=$DEVICE_COMMON_HOLDER
+   else
+       unset DEVICE_COMMON
+   fi
+      if [ -n "$PLATFORM_COMMON_HOLDER" ]; then
+       PLATFORM_COMMON=$PLATFORM_COMMON_HOLDER
+   else
+       unset PLATFORM_COMMON
+   fi
 }
 
 DEVICE=${1:=${DEVICE}}
@@ -57,7 +113,6 @@ else
 
     # Synchronize new new sources
     repo sync -c -j$JOBS -q $REPO_ARGS || cat $REPO_ROOT/.repo/local_manifests/*.xml
-
     # Refresh the device & common repositories so apks and jars are not copied
     # For this to work, all apks and jars need to be removed from
     # device/$VENDOR/$DEVICE/*proprietary-files*.txt and
@@ -72,6 +127,7 @@ else
     # We use a small workaround in order to catch these as well.
     if [ $VENDOR="oneplus" ]; then
         DEVICE_COMMON_TEMP2=$(ls -d $REPO_ROOT/device/oppo/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev)
+        VENDOR_COMMON_TEMP2=$(ls -d $REPO_ROOT/vendor/oppo/*common* 2>/dev/null | rev | cut -d "/" -f1 | rev)
         VENDOR2="oppo"
     fi
 
@@ -140,133 +196,33 @@ else
     # Loop through values in $DEVICE_COMMON_TEMP
     if [ -n "$DEVICE_COMMON_TEMP" ]; then
         for k in $DEVICE_COMMON_TEMP; do
-            echo "I: Procession device vendor common folder: device/$VENDOR/$k"
-            DEVICE_COMMON_TREE=$REPO_ROOT/device/$VENDOR/$k
-
-            # We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or
-            # $PLATFORM_COMMON available for setup-makefiles.sh in the common
-            # repository, therefore export them.
-            export VENDOR
-            export DEVICE
-            DEVICE_COMMON_HOLDER=$DEVICE_COMMON
-            export DEVICE_COMMON=${DEVICE_COMMON:=$k}
-            PLATFORM_COMMON_HOLDER=$PLATFORM_COMMON
-            export PLATFORM_COMMON=${PLATFORM_COMMON:=$DEVICE_COMMON}
-
-            if [ -f $DEVICE_COMMON_TREE/setup-makefiles.sh ]; then
-                (
-                    cd $DEVICE_COMMON_TREE
-                    for l in $(find . -name "*proprietary-*.txt"); do
-                        echo "I: Processing proprietary blob file: device/$VENDOR/$k/$l"
-                        grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $l >$l".tmp" && mv $l".tmp" $l
-                    done
-                    # Set executable bit, needed for some device trees
-                    chmod +x ./setup-makefiles.sh
-                    # Actually run the script
-                    ./setup-makefiles.sh
-                )
-            fi
-
-            # Since we don't use SELinux we want to make sure we remove the
-            # ",context=u....:s0" from the fstab file(s) in the $DEVICE_COMMON
-            # folder so we can mount the partitions without issues
-            cd $DEVICE_COMMON_TREE && for m in $(find . -name "fstab*"); do
-                echo "I: Processing fstab file: device/$VENDOR/$m"
-                sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
-            done
-
-            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
-            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
-            cd $DEVICE_COMMON_TREE
-            echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
-            removeUnneededFolders
-
-            # Since we can have multiple common repos we need to make sure to set
-            # back the original values in case they exist. Otherwise unset the value.
-            if [ -n "$DEVICE_COMMON_HOLDER" ]; then
-                DEVICE_COMMON=$DEVICE_COMMON_HOLDER
-            else
-                unset DEVICE_COMMON
-            fi
-            if [ -n "$PLATFORM_COMMON_HOLDER" ]; then
-                PLATFORM_COMMON=$PLATFORM_COMMON_HOLDER
-            else
-                unset PLATFORM_COMMON
-            fi
+            stripCommonFolder "device" "$VENDOR" "$k"
         done
     fi
 
-    # Loop through values in $DEVICE_COMMON_TEMP2 for certain OnePlus target
+    # Loop through values in $DEVICE_COMMON_TEMP2
     if [ -n "$DEVICE_COMMON_TEMP2" ]; then
         for k in $DEVICE_COMMON_TEMP2; do
-            echo "I: Procession device vendor common folder: device/$VENDOR2/$k"
-            DEVICE_COMMON_TREE2=$REPO_ROOT/device/$VENDOR2/$k
-
-            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
-            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
-            cd $DEVICE_COMMON_TREE2
-            echo "I: Removing components relying on SettingsLib from: device/$VENDOR2/$k"
-            removeUnneededFolders
+            stripCommonFolder "device" "$VENDOR2" "$k"
         done
     fi
 
     # Loop through values in $VENDOR_COMMON_TEMP
     if [ -n "$VENDOR_COMMON_TEMP" ]; then
         for k in $VENDOR_COMMON_TEMP; do
-            echo "I: Processing vendor vendor common folder: /vendor/$VENDOR/$k"
-            VENDOR_COMMON_TREE=$REPO_ROOT/vendor/$VENDOR/$k
-
-            # We need to have $VENDOR, $DEVICE and $DEVICE_COMMON or
-            # $PLATFORM_COMMON available for setup-makefiles.sh in the common
-            # repository, therefore export them.
-            export VENDOR
-            export DEVICE
-            DEVICE_COMMON_HOLDER=$DEVICE_COMMON
-            export DEVICE_COMMON=${DEVICE_COMMON:=$k}
-            PLATFORM_COMMON_HOLDER=$PLATFORM_COMMON
-            export PLATFORM_COMMON=${PLATFORM_COMMON:=$DEVICE_COMMON}
-
-            if [ -f $VENDOR_COMMON_TREE/setup-makefiles.sh ]; then
-                (
-                    cd $VENDOR_COMMON_TREE
-                    for l in $(find . -name "*proprietary-*.txt"); do
-                        echo "I: Processing proprietary blob file: $VENDOR_COMMON_TREE/$l"
-                        grep -r -v -E '(^.*\.{1}(jar|apk)[|]?.*)' $l >$l".tmp" && mv $l".tmp" $l
-                    done
-                    # Set executable bit, needed for some device trees
-                    chmod +x ./setup-makefiles.sh
-                    # Actually run the script
-                    ./setup-makefiles.sh
-                )
-            fi
-
-            # Since we don't use SELinux we want to make sure we remove the
-            # ",context=u....:s0" from the fstab file(s) in the $VENDOR_COMMON
-            # folder so we can mount the partitions without issues
-            cd $VENDOR_COMMON_TREE && for m in $(find . -name "fstab*"); do
-                echo "I: Processing fstab file: device/$VENDOR/$k/$m"
-                sed -r 's/(,context=.*:s0)//' $m >$m".tmp" && mv $m".tmp" $m
-            done
-
-            # Since we don't have SettingsLib, remove components that rely on it (which we therefore also don't use)
-            # such as CMActions/LineageActions, KeyHandler and Doze. Simply removing the folder will disable them.
-            cd $VENDOR_COMMON_TREE
-            echo "I: Removing components relying on SettingsLib from: device/$VENDOR/$k"
-            removeUnneededFolders
-
-            # Since we can have multiple common repos we need to make sure to set
-            # back the original values in case they exist. Otherwise unset the value.
-            if [ -n "$DEVICE_COMMON_HOLDER" ]; then
-                DEVICE_COMMON=$DEVICE_COMMON_HOLDER
-            else
-                unset DEVICE_COMMON
-            fi
-            if [ -n "$PLATFORM_COMMON_HOLDER" ]; then
-                PLATFORM_COMMON=$PLATFORM_COMMON_HOLDER
-            else
-                unset PLATFORM_COMMON
-            fi
+            stripCommonFolder "vendor" "$VENDOR" "$k"
         done
     fi
+
+    # Loop through values in $VENDOR_COMMON_TEMP2
+    if [ -n "$VENDOR_COMMON_TEMP2" ]; then
+        for k in $VENDOR_COMMON_TEMP2; do
+            stripCommonFolder "vendor" "$VENDOR2" "$k"
+        done
+    fi
+
     echo "*******************************************"
 fi
+
+
+

--- a/setup
+++ b/setup
@@ -113,6 +113,7 @@ else
 
     # Synchronize new new sources
     repo sync -c -j$JOBS -q $REPO_ARGS || cat $REPO_ROOT/.repo/local_manifests/*.xml
+    
     # Refresh the device & common repositories so apks and jars are not copied
     # For this to work, all apks and jars need to be removed from
     # device/$VENDOR/$DEVICE/*proprietary-files*.txt and
@@ -220,9 +221,5 @@ else
             stripCommonFolder "vendor" "$VENDOR2" "$k"
         done
     fi
-
     echo "*******************************************"
 fi
-
-
-

--- a/setup
+++ b/setup
@@ -113,7 +113,7 @@ else
 
     # Synchronize new new sources
     repo sync -c -j$JOBS -q $REPO_ARGS || cat $REPO_ROOT/.repo/local_manifests/*.xml
-    
+
     # Refresh the device & common repositories so apks and jars are not copied
     # For this to work, all apks and jars need to be removed from
     # device/$VENDOR/$DEVICE/*proprietary-files*.txt and


### PR DESCRIPTION
This became necessary since Oneplus has 2nd vendor oppo, and since Lineage 16.0 they have a common repo also in oppo folder, which was not stripped properly until now.
